### PR TITLE
Michael toggle driver post endpoint

### DIFF
--- a/src/main/java/edu/ucsb/cs156/gauchoride/controllers/UsersController.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/controllers/UsersController.java
@@ -82,4 +82,16 @@ public class UsersController extends ApiController {
         return genericMessage("User with id %s has toggled admin status".formatted(id));
     }
 
+    @ApiOperation(value = "Toggle the driver field")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PostMapping("/toggleDriver")
+    public Object toggleDriver( @ApiParam("id") @RequestParam Long id){
+        User user = userRepository.findById(id)
+        .orElseThrow(() -> new EntityNotFoundException(User.class, id));
+
+        user.setDriver(!user.getDriver());
+        userRepository.save(user);
+        return genericMessage("User with id %s has toggled driver status".formatted(id));
+    }
+
 }

--- a/src/test/java/edu/ucsb/cs156/gauchoride/controllers/UsersControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/gauchoride/controllers/UsersControllerTests.java
@@ -234,7 +234,7 @@ public class UsersControllerTests extends ControllerTestCase {
 
   @WithMockUser(roles = { "ADMIN", "USER" })
   @Test
-  public void admin_tries_to_toggle_non_existant_user_and_gets_right_error_message() throws Exception {
+  public void admin_tries_to_toggleAdmin_non_existant_user_and_gets_right_error_message() throws Exception {
           // arrange
         
     
@@ -243,6 +243,94 @@ public class UsersControllerTests extends ControllerTestCase {
           // act
           MvcResult response = mockMvc.perform(
                           post("/api/admin/users/toggleAdmin?id=15")
+                                          .with(csrf()))
+                          .andExpect(status().isNotFound()).andReturn();
+
+          // assert
+          verify(userRepository, times(1)).findById(15L);
+         
+
+          Map<String, Object> json = responseToJson(response);
+          assertEquals("User with id 15 not found", json.get("message"));
+  }
+
+  @WithMockUser(roles = { "ADMIN", "USER" })
+  @Test
+  public void admin_can_toggle_driver_status_of_a_user_from_false_to_true() throws Exception {
+          // arrange
+          User userBefore = User.builder()
+          .email("cgaucho@ucsb.edu")
+          .id(15L)
+          .driver(false)
+          .build();
+
+          User userAfter = User.builder()
+          .email("cgaucho@ucsb.edu")
+          .id(15L)
+          .driver(true)
+          .build();
+
+    
+          when(userRepository.findById(eq(15L))).thenReturn(Optional.of(userBefore));
+          when(userRepository.save(eq(userAfter))).thenReturn(userAfter);
+          // act
+          MvcResult response = mockMvc.perform(
+                          post("/api/admin/users/toggleDriver?id=15")
+                                          .with(csrf()))
+                          .andExpect(status().isOk()).andReturn();
+
+          // assert
+          verify(userRepository, times(1)).findById(15L);
+          verify(userRepository, times(1)).save(userAfter);
+
+          Map<String, Object> json = responseToJson(response);
+          assertEquals("User with id 15 has toggled driver status", json.get("message"));
+  }
+
+  @WithMockUser(roles = { "ADMIN", "USER" })
+  @Test
+  public void admin_can_toggle_driver_status_of_a_user_from_true_to_false() throws Exception {
+          // arrange
+          User userBefore = User.builder()
+          .email("cgaucho@ucsb.edu")
+          .id(15L)
+          .driver(true)
+          .build();
+
+          User userAfter = User.builder()
+          .email("cgaucho@ucsb.edu")
+          .id(15L)
+          .driver(false)
+          .build();
+
+    
+          when(userRepository.findById(eq(15L))).thenReturn(Optional.of(userBefore));
+          when(userRepository.save(eq(userAfter))).thenReturn(userAfter);
+          // act
+          MvcResult response = mockMvc.perform(
+                          post("/api/admin/users/toggleDriver?id=15")
+                                          .with(csrf()))
+                          .andExpect(status().isOk()).andReturn();
+
+          // assert
+          verify(userRepository, times(1)).findById(15L);
+          verify(userRepository, times(1)).save(userAfter);
+
+          Map<String, Object> json = responseToJson(response);
+          assertEquals("User with id 15 has toggled driver status", json.get("message"));
+  }
+
+  @WithMockUser(roles = { "ADMIN", "USER" })
+  @Test
+  public void admin_tries_to_toggleDriver_non_existant_user_and_gets_right_error_message() throws Exception {
+          // arrange
+        
+    
+          when(userRepository.findById(eq(15L))).thenReturn(Optional.empty());
+          
+          // act
+          MvcResult response = mockMvc.perform(
+                          post("/api/admin/users/toggleDriver?id=15")
                                           .with(csrf()))
                           .andExpect(status().isNotFound()).andReturn();
 


### PR DESCRIPTION
In the PR we add the backend endpoint `api/admin/users/toggleDriver` for toggling the `driver` flag of a user.  It is included under `api/admin` since only admins should be able to `toggleDriver`.  Closes #14 