### PR TITLE
Michael toggle driver button

### DIFF
--- a/frontend/src/main/components/Users/UsersTable.js
+++ b/frontend/src/main/components/Users/UsersTable.js
@@ -6,6 +6,7 @@ import { useBackendMutation } from "main/utils/useBackend";
 
 export default function UsersTable({ users}) {
 
+    //toggleAdmin
     function cellToAxiosParamsToggleAdmin(cell) {
         return {
             url: "/api/admin/users/toggleAdmin",
@@ -26,6 +27,29 @@ export default function UsersTable({ users}) {
 
     // Stryker disable next-line all : TODO try to make a good test for this
     const toggleAdminCallback = async (cell) => { toggleAdminMutation.mutate(cell); }
+
+
+    //toggleDriver
+    function cellToAxiosParamsToggleDriver(cell) {
+        return {
+            url: "/api/admin/users/toggleDriver",
+            method: "POST",
+            params: {
+                id: cell.row.values.id
+            }
+        }
+    }
+
+    // Stryker disable all : hard to test for query caching
+    const toggleDriverMutation = useBackendMutation(
+        cellToAxiosParamsToggleDriver,
+        {},
+        ["/api/admin/users"]
+    );
+    // Stryker enable all 
+
+    // Stryker disable next-line all : TODO try to make a good test for this
+    const toggleDriverCallback = async (cell) => { toggleDriverMutation.mutate(cell); }
 
 
     const columns = [
@@ -60,6 +84,7 @@ export default function UsersTable({ users}) {
     const buttonColumn = [
         ...columns,
         ButtonColumn("toggle-admin", "primary", toggleAdminCallback, "UsersTable"),
+        ButtonColumn("toggle-driver", "primary", toggleDriverCallback, "UsersTable"),
     ]
 
     //const columnsToDisplay = showButtons ? buttonColumn : columns;

--- a/frontend/src/tests/components/Users/UsersTable.test.js
+++ b/frontend/src/tests/components/Users/UsersTable.test.js
@@ -23,7 +23,7 @@ describe("UserTable tests", () => {
         );
     });
 
-    test("Has the expected colum headers and content", () => {
+    test("Has the expected column headers and content", () => {
         const { getByText, getByTestId } = render(
             <QueryClientProvider client={queryClient}>
                 <UsersTable users={usersFixtures.threeUsers}/>

--- a/frontend/src/tests/pages/AdminUsersPage.test.js
+++ b/frontend/src/tests/pages/AdminUsersPage.test.js
@@ -92,6 +92,32 @@ describe("AdminUsersPage tests", () => {
         expect(axiosMock.history.post[0].params).toEqual({id:1});
       
 
+    });
+
+    test("usertable toggle driver tests", async ()=>{
+        setupAdminUser();
+        const queryClient = new QueryClient();
+        axiosMock.onGet("/api/admin/users").reply(200, usersFixtures.threeUsers);
+        axiosMock.onPost("/api/admin/users/toggleDriver").reply(200, "User with id 1 has toggled driver status");
+        const { getByText} = render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <AdminUsersPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+        await waitFor(() => expect(getByText("Users")).toBeInTheDocument());
+
+        const toggleDriverButton = screen.getByTestId(`${testId}-cell-row-0-col-toggle-driver-button`);
+        expect(toggleDriverButton).toBeInTheDocument();
+
+        fireEvent.click(toggleDriverButton);
+
+        await waitFor(() => expect(axiosMock.history.post.length).toBe(1));
+        expect(axiosMock.history.post[0].url).toBe("/api/admin/users/toggleDriver");
+        expect(axiosMock.history.post[0].params).toEqual({id:1});
+      
+
     })
 
 });

--- a/src/main/java/edu/ucsb/cs156/gauchoride/controllers/UsersController.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/controllers/UsersController.java
@@ -82,4 +82,16 @@ public class UsersController extends ApiController {
         return genericMessage("User with id %s has toggled admin status".formatted(id));
     }
 
+    @ApiOperation(value = "Toggle the driver field")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PostMapping("/toggleDriver")
+    public Object toggleDriver( @ApiParam("id") @RequestParam Long id){
+        User user = userRepository.findById(id)
+        .orElseThrow(() -> new EntityNotFoundException(User.class, id));
+
+        user.setDriver(!user.getDriver());
+        userRepository.save(user);
+        return genericMessage("User with id %s has toggled driver status".formatted(id));
+    }
+
 }

--- a/src/test/java/edu/ucsb/cs156/gauchoride/controllers/UsersControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/gauchoride/controllers/UsersControllerTests.java
@@ -234,7 +234,7 @@ public class UsersControllerTests extends ControllerTestCase {
 
   @WithMockUser(roles = { "ADMIN", "USER" })
   @Test
-  public void admin_tries_to_toggle_non_existant_user_and_gets_right_error_message() throws Exception {
+  public void admin_tries_to_toggleAdmin_non_existant_user_and_gets_right_error_message() throws Exception {
           // arrange
         
     
@@ -243,6 +243,94 @@ public class UsersControllerTests extends ControllerTestCase {
           // act
           MvcResult response = mockMvc.perform(
                           post("/api/admin/users/toggleAdmin?id=15")
+                                          .with(csrf()))
+                          .andExpect(status().isNotFound()).andReturn();
+
+          // assert
+          verify(userRepository, times(1)).findById(15L);
+         
+
+          Map<String, Object> json = responseToJson(response);
+          assertEquals("User with id 15 not found", json.get("message"));
+  }
+
+  @WithMockUser(roles = { "ADMIN", "USER" })
+  @Test
+  public void admin_can_toggle_driver_status_of_a_user_from_false_to_true() throws Exception {
+          // arrange
+          User userBefore = User.builder()
+          .email("cgaucho@ucsb.edu")
+          .id(15L)
+          .driver(false)
+          .build();
+
+          User userAfter = User.builder()
+          .email("cgaucho@ucsb.edu")
+          .id(15L)
+          .driver(true)
+          .build();
+
+    
+          when(userRepository.findById(eq(15L))).thenReturn(Optional.of(userBefore));
+          when(userRepository.save(eq(userAfter))).thenReturn(userAfter);
+          // act
+          MvcResult response = mockMvc.perform(
+                          post("/api/admin/users/toggleDriver?id=15")
+                                          .with(csrf()))
+                          .andExpect(status().isOk()).andReturn();
+
+          // assert
+          verify(userRepository, times(1)).findById(15L);
+          verify(userRepository, times(1)).save(userAfter);
+
+          Map<String, Object> json = responseToJson(response);
+          assertEquals("User with id 15 has toggled driver status", json.get("message"));
+  }
+
+  @WithMockUser(roles = { "ADMIN", "USER" })
+  @Test
+  public void admin_can_toggle_driver_status_of_a_user_from_true_to_false() throws Exception {
+          // arrange
+          User userBefore = User.builder()
+          .email("cgaucho@ucsb.edu")
+          .id(15L)
+          .driver(true)
+          .build();
+
+          User userAfter = User.builder()
+          .email("cgaucho@ucsb.edu")
+          .id(15L)
+          .driver(false)
+          .build();
+
+    
+          when(userRepository.findById(eq(15L))).thenReturn(Optional.of(userBefore));
+          when(userRepository.save(eq(userAfter))).thenReturn(userAfter);
+          // act
+          MvcResult response = mockMvc.perform(
+                          post("/api/admin/users/toggleDriver?id=15")
+                                          .with(csrf()))
+                          .andExpect(status().isOk()).andReturn();
+
+          // assert
+          verify(userRepository, times(1)).findById(15L);
+          verify(userRepository, times(1)).save(userAfter);
+
+          Map<String, Object> json = responseToJson(response);
+          assertEquals("User with id 15 has toggled driver status", json.get("message"));
+  }
+
+  @WithMockUser(roles = { "ADMIN", "USER" })
+  @Test
+  public void admin_tries_to_toggleDriver_non_existant_user_and_gets_right_error_message() throws Exception {
+          // arrange
+        
+    
+          when(userRepository.findById(eq(15L))).thenReturn(Optional.empty());
+          
+          // act
+          MvcResult response = mockMvc.perform(
+                          post("/api/admin/users/toggleDriver?id=15")
                                           .with(csrf()))
                           .andExpect(status().isNotFound()).andReturn();
 


### PR DESCRIPTION
In this PR we add the toggle-driver column to the users table which is visible only to admin users; it uses the `/api/admin/users/toggleDriver` endpoint (so this PR should be merged after PR #22 for reduced conflicts).  Closes #15 