### PR TITLE
amey - Add entity and repository file for Driver shift table

### DIFF
--- a/src/main/java/edu/ucsb/cs156/gauchoride/entities/Shift.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/entities/Shift.java
@@ -21,6 +21,6 @@ public class Shift {
   private long id;
   private String day;
   private String shift;
-  private String driver;
-  private String driverBackup;
+  private long driverID;
+  private long driverBackupID;
 }

--- a/src/main/java/edu/ucsb/cs156/gauchoride/entities/Shift.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/entities/Shift.java
@@ -9,6 +9,7 @@ import javax.persistence.Entity;
 import javax.persistence.Id;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
+import java.time.LocalTime;
 
 @Data
 @AllArgsConstructor
@@ -20,7 +21,8 @@ public class Shift {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private long id;
   private String day;
-  private String shift;
+  private LocalTime shiftStart;
+  private LocalTime shiftEnd;
   private long driverID;
   private long driverBackupID;
 }

--- a/src/main/java/edu/ucsb/cs156/gauchoride/entities/Shift.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/entities/Shift.java
@@ -19,7 +19,6 @@ public class Shift {
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private long id;
-  
   private String day;
   private String shift;
   private String driver;

--- a/src/main/java/edu/ucsb/cs156/gauchoride/entities/Shift.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/entities/Shift.java
@@ -1,0 +1,27 @@
+package edu.ucsb.cs156.gauchoride.entities;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.AccessLevel;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+@Entity(name = "shift")
+public class Shift {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private long id;
+  
+  private String day;
+  private String shift;
+  private String driver;
+  private String driverBackup;
+}

--- a/src/main/java/edu/ucsb/cs156/gauchoride/repositories/ShiftRepository.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/repositories/ShiftRepository.java
@@ -4,6 +4,7 @@ import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
 
 import edu.ucsb.cs156.gauchoride.entities.Shift;
+import java.time.LocalTime;
 
 import java.util.Optional;
 
@@ -11,6 +12,5 @@ import java.util.Optional;
 public interface ShiftRepository extends CrudRepository<Shift, Long> {
   Optional<Shift> findByDay(String day);
   Optional<Shift> findByDriver(Long driverID);
-  // TODO: Find by shift would be nice to have, it might be a little difficult to implement
-  //Optional<Shift> findByShift(String shift);
+  Optional<Shift> findByShift(LocalTime shiftStart, LocalTime shiftEnd);
 }

--- a/src/main/java/edu/ucsb/cs156/gauchoride/repositories/ShiftRepository.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/repositories/ShiftRepository.java
@@ -1,0 +1,16 @@
+package edu.ucsb.cs156.gauchoride.repositories;
+
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+import edu.ucsb.cs156.gauchoride.entities.Shift;
+
+import java.util.Optional;
+
+@Repository
+public interface ShiftRepository extends CrudRepository<Shift, Long> {
+  Optional<Shift> findByDay(String day);
+  Optional<Shift> findByDriver(Long driverID);
+  // TODO: Find by shift would be nice to have, it might be a little difficult to implement
+  //Optional<Shift> findByShift(String shift);
+}


### PR DESCRIPTION
In this PR, I create an entity file for the driver shift table. As seen in the spreadsheet below, the Shift entity will have an id, day, shift, driver, and driver backup. 
![image](https://github.com/ucsb-cs156-s23/proj-gauchoride-s23-5pm-4/assets/12536187/18fc492d-2282-47f9-b57e-c45262be6bff)