### PR TITLE
Anikait - Get/Post Operations for Ride Requests, with same paths for all roles.

### DIFF
--- a/src/main/java/edu/ucsb/cs156/gauchoride/controllers/RideController.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/controllers/RideController.java
@@ -1,0 +1,101 @@
+package edu.ucsb.cs156.gauchoride.controllers;
+
+import edu.ucsb.cs156.gauchoride.entities.Ride;
+import edu.ucsb.cs156.gauchoride.errors.EntityNotFoundException;
+import edu.ucsb.cs156.gauchoride.repositories.RideRepository;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.oauth2.jwt.NimbusReactiveJwtDecoder.SecretKeyReactiveJwtDecoderBuilder;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.validation.Valid;
+
+
+@Api(description = "Ride Request")
+@RequestMapping("/api/ride_request")
+@RestController
+
+public class RideController extends ApiController {
+
+    @Autowired
+    RideRepository rideRepository;
+
+    @ApiOperation(value = "List all rides")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @GetMapping("/admin/all")
+    public Iterable<Ride> allRides() {
+        Iterable<Ride> rides = rideRepository.findAll();
+        return rides;
+    }
+
+    @ApiOperation(value = "List all user's rides")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping("/all")
+    public Iterable<Ride> allRidesForUser() {
+        Iterable<Ride> rides = rideRepository.findAllByRiderId(getCurrentUser().getUser().getId());
+        return rides;
+    }
+
+    @ApiOperation(value = "Get any single ride")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @GetMapping("/admin")
+    public Ride getById(
+            @ApiParam("id") @RequestParam Long id) {
+        Ride ride = rideRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(Ride.class, id));
+
+        return ride;
+    }
+
+    @ApiOperation(value = "Get a single ride, if it belongs to user")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping("")
+    public Ride getByIdForUser(
+            @ApiParam("id") @RequestParam Long id) {
+        Ride ride = rideRepository.findByIdAndRiderId(id, getCurrentUser().getUser().getId())
+                .orElseThrow(() -> new EntityNotFoundException(Ride.class, id));
+
+        return ride;
+    }
+
+    @ApiOperation(value = "Create a new ride")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @PostMapping("/post")
+    public Ride postRide(
+        @ApiParam("day") @RequestParam String day,
+        @ApiParam("startTime") @RequestParam String startTime,
+        @ApiParam("endTime") @RequestParam String endTime,
+        @ApiParam("pickupLocation") @RequestParam String pickupLocation,
+        @ApiParam("dropoffLocation") @RequestParam String dropoffLocation,
+        @ApiParam("room") @RequestParam String room,
+        @ApiParam("course") @RequestParam String course
+        )
+        {
+
+        Ride ride = new Ride();
+        
+        ride.setRiderId(getCurrentUser().getUser().getId());
+        ride.setDay(day);
+        ride.setStartTime(startTime);
+        ride.setEndTime(endTime);
+        ride.setPickupLocation(pickupLocation);
+        ride.setDropoffLocation(dropoffLocation);
+        ride.setRoom(room);
+        ride.setCourse(course);
+
+        Ride savedRide = rideRepository.save(ride);
+
+        return savedRide;
+    }
+}

--- a/src/main/java/edu/ucsb/cs156/gauchoride/controllers/RideController.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/controllers/RideController.java
@@ -52,7 +52,9 @@ public class RideController extends ApiController {
     @PreAuthorize("hasRole('ROLE_ADMIN') || hasRole('ROLE_DRIVER') || hasRole('ROLE_USER')")
     @GetMapping("")
     public Ride getByIdForUser(
-            @ApiParam("id") @RequestParam Long id) {
+            @ApiParam(name="id", type="long", value = "Id of the Ride", 
+            required = true)  
+            @RequestParam Long id) {
         Ride ride;
         
         if (getCurrentUser().getRoles().contains(new SimpleGrantedAuthority("ROLE_ADMIN")) ||
@@ -71,13 +73,27 @@ public class RideController extends ApiController {
     @PreAuthorize("hasRole('ROLE_USER')")
     @PostMapping("/post")
     public Ride postRide(
-        @ApiParam("day") @RequestParam String day,
-        @ApiParam("startTime") @RequestParam String startTime,
-        @ApiParam("endTime") @RequestParam String endTime,
-        @ApiParam("pickupLocation") @RequestParam String pickupLocation,
-        @ApiParam("dropoffLocation") @RequestParam String dropoffLocation,
-        @ApiParam("room") @RequestParam String room,
-        @ApiParam("course") @RequestParam String course
+        @ApiParam(name="day", type="String", value = "Day of the week ride is requested (Monday - Sunday)", example="Tuesday", 
+                    required = true, allowableValues = "Monday, Tuesday, Wednesday, Thursday, Friday, Saturday, Sunday") 
+        @RequestParam String day,
+
+        @ApiParam(name="startTime", type="String", value = "Time the ride starts HH:MM(A/P)M", example="12:30AM", required = true)
+        @RequestParam String startTime,
+
+        @ApiParam(name="endTime", type="String", value = "Time the ride ends HH:MM(A/P)M", example="12:30AM", required = true)
+        @RequestParam String endTime,
+
+        @ApiParam(name="pickupLocation", type="String", value = "Location the ride starts", example="Phelps Hall", required = true)
+        @RequestParam String pickupLocation,
+
+        @ApiParam(name="dropoffLocation", type="String", value = "Location the ride ends", example="South Hall", required = true)
+        @RequestParam String dropoffLocation,
+
+        @ApiParam(name="room", type="String", value = "Room number for the dropoffLocation", example="1431", required = true)
+        @RequestParam String room,
+
+        @ApiParam(name="course", type="String", value = "Course number for the class at the dropoffLocation", example="CMPSC 156", required = true)
+        @RequestParam String course
         )
         {
 

--- a/src/main/java/edu/ucsb/cs156/gauchoride/controllers/RideController.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/controllers/RideController.java
@@ -31,8 +31,8 @@ public class RideController extends ApiController {
     @Autowired
     RideRepository rideRepository;
 
-    @ApiOperation(value = "List all rides")
-    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @ApiOperation(value = "List all rides (admin/driver only)")
+    @PreAuthorize("hasRole('ROLE_ADMIN') || hasRole('ROLE_DRIVER')")
     @GetMapping("/admin/all")
     public Iterable<Ride> allRides() {
         Iterable<Ride> rides = rideRepository.findAll();
@@ -47,8 +47,8 @@ public class RideController extends ApiController {
         return rides;
     }
 
-    @ApiOperation(value = "Get any single ride")
-    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @ApiOperation(value = "Get any single ride (admin/driver only)")
+    @PreAuthorize("hasRole('ROLE_ADMIN') || hasRole('ROLE_DRIVER')")
     @GetMapping("/admin")
     public Ride getById(
             @ApiParam("id") @RequestParam Long id) {

--- a/src/main/java/edu/ucsb/cs156/gauchoride/repositories/RideRepository.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/repositories/RideRepository.java
@@ -4,9 +4,10 @@ import edu.ucsb.cs156.gauchoride.entities.Ride;
 
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
-
+import java.util.Optional;
 
 @Repository
 public interface RideRepository extends CrudRepository<Ride, Long> {
   Iterable<Ride> findAllByRiderId(long riderId);
+  Optional<Ride> findByIdAndRiderId(long id, long riderId);
 }

--- a/src/main/java/edu/ucsb/cs156/gauchoride/repositories/ShiftRepository.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/repositories/ShiftRepository.java
@@ -11,6 +11,6 @@ import java.util.Optional;
 @Repository
 public interface ShiftRepository extends CrudRepository<Shift, Long> {
   Optional<Shift> findByDay(String day);
-  Optional<Shift> findByDriver(Long driverID);
-  Optional<Shift> findByShift(LocalTime shiftStart, LocalTime shiftEnd);
+  Optional<Shift> findByDriverID(Long driverID);
+  Optional<Shift> findByShiftStartAndShiftEnd(LocalTime shiftStart, LocalTime shiftEnd);
 }

--- a/src/test/java/edu/ucsb/cs156/gauchoride/controllers/RideControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/gauchoride/controllers/RideControllerTests.java
@@ -40,110 +40,63 @@ public class RideControllerTests extends ControllerTestCase {
         @MockBean
         UserRepository userRepository;
 
-        // Authorization tests for /api/ride_request/admin/all
-
-        @Test
-        public void logged_out_users_cannot_get_all_admin_backend() throws Exception {
-                mockMvc.perform(get("/api/ride_request/admin/all"))
-                                .andExpect(status().is(403)); // logged out users can't get all
-        }
-
-        @WithMockUser(roles = { "USER" })
-        @Test
-        public void logged_in_users_not_admin_cannot_get_all_admin_backend() throws Exception {
-                mockMvc.perform(get("/api/ride_request/admin/all"))
-                                .andExpect(status().is(403)); // logged in users can't get all unless admin
-        }
-
-        @WithMockUser(roles = { "ADMIN" })
-        @Test
-        public void logged_in_admin_can_get_all_admin_backend() throws Exception {
-                mockMvc.perform(get("/api/ride_request/admin/all"))
-                                .andExpect(status().is(200)); // logged
-        }
-
-        @WithMockUser(roles = { "DRIVER" })
-        @Test
-        public void logged_in_driver_can_get_all_admin_backend() throws Exception {
-                mockMvc.perform(get("/api/ride_request/admin/all"))
-                                .andExpect(status().is(200)); // logged
-        }
-
         // Authorization tests for /api/ride_request/all
 
         @Test
-        public void logged_out_users_cannot_get_any_rides() throws Exception {
+        public void logged_out_users_cannot_get_all() throws Exception {
                 mockMvc.perform(get("/api/ride_request/all"))
                                 .andExpect(status().is(403)); // logged out users can't get all
         }
 
         @WithMockUser(roles = { "USER" })
         @Test
-        public void logged_in_users_can_get_their_rides() throws Exception {
+        public void logged_in_users_can_get_all_of_theirs() throws Exception {
                 mockMvc.perform(get("/api/ride_request/all"))
-                                .andExpect(status().is(200)); // logged in users can't get all unless admin
+                                .andExpect(status().is(200)); // logged
         }
 
         @WithMockUser(roles = { "DRIVER" })
         @Test
-        public void logged_in_drivers_cannot_get_their_rides() throws Exception {
+        public void logged_in_driver_can_get_all() throws Exception {
                 mockMvc.perform(get("/api/ride_request/all"))
-                                .andExpect(status().is(403)); // drivers don't have rides
-        }
-
-        // Authorization tests for /api/ride_request/admin?id={}
-
-        @Test
-        public void logged_out_users_cannot_get_by_id_admin_backend() throws Exception {
-                mockMvc.perform(get("/api/ride_request/admin?id=7"))
-                                .andExpect(status().is(403)); // logged out users can't get by id
-        }
-
-        @WithMockUser(roles = { "USER" })
-        @Test
-        public void logged_in_users_not_admin_cannot_get_by_id_admin_backend() throws Exception {
-                mockMvc.perform(get("/api/ride_request/admin?id=7"))
-                                .andExpect(status().is(403)); // logged in users can't get by id using admin backend
+                                .andExpect(status().is(200)); // logged
         }
 
         @WithMockUser(roles = { "ADMIN" })
         @Test
-        public void logged_in_admin_can_get_by_id_admin_backend() throws Exception {
-                mockMvc.perform(get("/api/ride_request/admin?id=7"))
-                                .andExpect(status().is(404)); // logged, but no id exists
-        }
-
-        @WithMockUser(roles = { "DRIVER" })
-        @Test
-        public void logged_in_driver_can_get_by_id_admin_backend() throws Exception {
-                mockMvc.perform(get("/api/ride_request/admin?id=7"))
-                                .andExpect(status().is(404)); // logged, but no id exists
+        public void logged_in_admin_can_get_all() throws Exception {
+                mockMvc.perform(get("/api/ride_request/all"))
+                                .andExpect(status().is(200)); // logged
         }
 
         // Authorization tests for /api/ride_request?id={}
 
         @Test
-        public void logged_out_users_cannot_get_any_by_id() throws Exception {
+        public void logged_out_users_cannot_get_by_id() throws Exception {
                 mockMvc.perform(get("/api/ride_request?id=7"))
                                 .andExpect(status().is(403)); // logged out users can't get by id
         }
 
         @WithMockUser(roles = { "USER" })
         @Test
-        public void logged_in_users_cannot_get_by_id_in_simple_test() throws Exception {
+        public void logged_in_users_can_get_by_id_that_is_theirs() throws Exception {
                 mockMvc.perform(get("/api/ride_request?id=7"))
-                                .andExpect(status().is(404)); 
-                // logged in users can get their rides by id unless their ride matches, no ride with id 7 exists
+                                .andExpect(status().is(404)); // logged, but no id exists
         }
 
         @WithMockUser(roles = { "DRIVER" })
         @Test
-        public void logged_in_driver_cannot_get_by_id_in_simple_test() throws Exception {
+        public void logged_in_driver_can_get_by_id() throws Exception {
                 mockMvc.perform(get("/api/ride_request?id=7"))
-                                .andExpect(status().is(403)); 
-                // logged in drivers don't have rides
+                                .andExpect(status().is(404)); // logged, but no id exists
         }
 
+        @WithMockUser(roles = { "ADMIN" })
+        @Test
+        public void logged_in_admin_can_get_by_id() throws Exception {
+                mockMvc.perform(get("/api/ride_request?id=7"))
+                                .andExpect(status().is(404)); // logged, but no id exists
+        }
 
         // Authorization tests for /api/ride_request/post
 
@@ -161,8 +114,6 @@ public class RideControllerTests extends ControllerTestCase {
         }
 
         // // Tests with mocks for database actions
-
-
 
 
 
@@ -284,7 +235,7 @@ public class RideControllerTests extends ControllerTestCase {
                 when(rideRepository.findById(eq(7L))).thenReturn(Optional.of(ride));
 
                 // act
-                MvcResult response = mockMvc.perform(get("/api/ride_request/admin?id=7"))
+                MvcResult response = mockMvc.perform(get("/api/ride_request?id=7"))
                                 .andExpect(status().isOk()).andReturn();
 
                 // assert
@@ -318,7 +269,7 @@ public class RideControllerTests extends ControllerTestCase {
                 when(rideRepository.findById(eq(7L))).thenReturn(Optional.of(ride));
 
                 // act
-                MvcResult response = mockMvc.perform(get("/api/ride_request/admin?id=7"))
+                MvcResult response = mockMvc.perform(get("/api/ride_request?id=7"))
                                 .andExpect(status().isOk()).andReturn();
 
                 // assert
@@ -338,7 +289,7 @@ public class RideControllerTests extends ControllerTestCase {
                 when(rideRepository.findById(eq(7L))).thenReturn(Optional.empty());
 
                 // act
-                MvcResult response = mockMvc.perform(get("/api/ride_request/admin?id=7"))
+                MvcResult response = mockMvc.perform(get("/api/ride_request?id=7"))
                                 .andExpect(status().isNotFound()).andReturn();
 
                 // assert
@@ -358,7 +309,7 @@ public class RideControllerTests extends ControllerTestCase {
                 when(rideRepository.findById(eq(7L))).thenReturn(Optional.empty());
 
                 // act
-                MvcResult response = mockMvc.perform(get("/api/ride_request/admin?id=7"))
+                MvcResult response = mockMvc.perform(get("/api/ride_request?id=7"))
                                 .andExpect(status().isNotFound()).andReturn();
 
                 // assert
@@ -464,7 +415,7 @@ public class RideControllerTests extends ControllerTestCase {
                 when(rideRepository.findAll()).thenReturn(expectedRides);
 
                 // act
-                MvcResult response = mockMvc.perform(get("/api/ride_request/admin/all"))
+                MvcResult response = mockMvc.perform(get("/api/ride_request/all"))
                                 .andExpect(status().isOk()).andReturn();
 
                 // assert
@@ -521,7 +472,7 @@ public class RideControllerTests extends ControllerTestCase {
                 when(rideRepository.findAll()).thenReturn(expectedRides);
 
                 // act
-                MvcResult response = mockMvc.perform(get("/api/ride_request/admin/all"))
+                MvcResult response = mockMvc.perform(get("/api/ride_request/all"))
                                 .andExpect(status().isOk()).andReturn();
 
                 // assert

--- a/src/test/java/edu/ucsb/cs156/gauchoride/controllers/RideControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/gauchoride/controllers/RideControllerTests.java
@@ -127,13 +127,6 @@ public class RideControllerTests extends ControllerTestCase {
                                 .andExpect(status().is(403));
         }
 
-        @WithMockUser(roles = { "USER" })
-        @Test
-        public void logged_in_regular_users_cannot_post() throws Exception {
-                mockMvc.perform(post("/api/ride_request/post"))
-                                .andExpect(status().is(403)); // only admins can post
-        }
-
         // // Tests with mocks for database actions
 
 
@@ -397,43 +390,42 @@ public class RideControllerTests extends ControllerTestCase {
 
 
 
-
         // POST
 
 
 
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void a_user_can_post_a_new_ride() throws Exception {
+                // arrange
 
+                long userId = currentUserService.getCurrentUser().getUser().getId();
 
-        // @WithMockUser(roles = { "ADMIN", "USER" })
-        // @Test
-        // public void an_admin_user_can_post_a_new_ride() throws Exception {
-        //         // arrange
+                Ride ride1 = Ride.builder()
+                        .riderId(userId)
+                        .day("Monday")
+                        .course("CMPSC 156")
+                        .startTime("2:00PM")
+                        .endTime("3:15PM")
+                        .dropoffLocation("South Hall")
+                        .pickupLocation("Phelps Hall")
+                        .room("1431")
+                        .build();
 
-        //         Ride ride1 = Ride.builder()
-        //                 .day("Monday")
-        //                 .student("CGaucho")
-        //                 .course("CMPSC 156")
-        //                 .start("2:00PM")
-        //                 .end("3:15PM")
-        //                 .dropoff("South Hall")
-        //                 .room("1431")
-        //                 .pickup("Phelps Hall")
-        //                 .build();
+                when(rideRepository.save(eq(ride1))).thenReturn(ride1);
 
-        //         when(rideRepository.save(eq(ride1))).thenReturn(ride1);
+                String postRequesString = "day=Monday&course=CMPSC 156&startTime=2:00PM&endTime=3:15PM&pickupLocation=Phelps Hall&dropoffLocation=South Hall&room=1431";
 
-        //         String postRequesString = "day=Monday&student=CGaucho&course=CMPSC 156&start=2:00PM&end=3:15PM&dropoff=South Hall&room=1431&pickup=Phelps Hall";
+                // act
+                MvcResult response = mockMvc.perform(
+                                post("/api/ride_request/post?" + postRequesString)
+                                                .with(csrf()))
+                                .andExpect(status().isOk()).andReturn();
 
-        //         // act
-        //         MvcResult response = mockMvc.perform(
-        //                         post("/api/ride_request/post?" + postRequesString)
-        //                                         .with(csrf()))
-        //                         .andExpect(status().isOk()).andReturn();
-
-        //         // assert
-        //         verify(rideRepository, times(1)).save(ride1);
-        //         String expectedJson = mapper.writeValueAsString(ride1);
-        //         String responseString = response.getResponse().getContentAsString();
-        //         assertEquals(expectedJson, responseString);
-        // }
+                // assert
+                verify(rideRepository, times(1)).save(ride1);
+                String expectedJson = mapper.writeValueAsString(ride1);
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(expectedJson, responseString);
+        }
 }

--- a/src/test/java/edu/ucsb/cs156/gauchoride/controllers/RideControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/gauchoride/controllers/RideControllerTests.java
@@ -1,0 +1,439 @@
+package edu.ucsb.cs156.gauchoride.controllers;
+
+import edu.ucsb.cs156.gauchoride.repositories.UserRepository;
+import edu.ucsb.cs156.gauchoride.testconfig.TestConfig;
+import edu.ucsb.cs156.gauchoride.ControllerTestCase;
+import edu.ucsb.cs156.gauchoride.entities.Ride;
+import edu.ucsb.cs156.gauchoride.repositories.RideRepository;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+
+// import java.time.LocalDateTime;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@WebMvcTest(controllers = RideController.class)
+@Import(TestConfig.class)
+public class RideControllerTests extends ControllerTestCase {
+
+        @MockBean
+        RideRepository rideRepository;
+
+        @MockBean
+        UserRepository userRepository;
+
+        // Authorization tests for /api/ride_request/admin/all
+
+        @Test
+        public void logged_out_users_cannot_get_all_admin_backend() throws Exception {
+                mockMvc.perform(get("/api/ride_request/admin/all"))
+                                .andExpect(status().is(403)); // logged out users can't get all
+        }
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void logged_in_users_not_admin_cannot_get_all_admin_backend() throws Exception {
+                mockMvc.perform(get("/api/ride_request/admin/all"))
+                                .andExpect(status().is(403)); // logged in users can't get all unless admin
+        }
+
+        @WithMockUser(roles = { "ADMIN" })
+        @Test
+        public void logged_in_admin_can_get_all_admin_backend() throws Exception {
+                mockMvc.perform(get("/api/ride_request/admin/all"))
+                                .andExpect(status().is(200)); // logged
+        }
+
+        // Authorization tests for /api/ride_request/all
+
+        @Test
+        public void logged_out_users_cannot_get_any_rides() throws Exception {
+                mockMvc.perform(get("/api/ride_request/all"))
+                                .andExpect(status().is(403)); // logged out users can't get all
+        }
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void logged_in_users_can_get_their_rides() throws Exception {
+                mockMvc.perform(get("/api/ride_request/all"))
+                                .andExpect(status().is(200)); // logged in users can't get all unless admin
+        }
+
+        // Authorization tests for /api/ride_request/admin?id={}
+
+        @Test
+        public void logged_out_users_cannot_get_by_id_admin_backend() throws Exception {
+                mockMvc.perform(get("/api/ride_request/admin?id=7"))
+                                .andExpect(status().is(403)); // logged out users can't get by id
+        }
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void logged_in_users_not_admin_cannot_get_by_id_admin_backend() throws Exception {
+                mockMvc.perform(get("/api/ride_request/admin?id=7"))
+                                .andExpect(status().is(403)); // logged in users can't get by id using admin backend
+        }
+
+        @WithMockUser(roles = { "ADMIN" })
+        @Test
+        public void logged_in_admin_can_get_by_id_admin_backend() throws Exception {
+                mockMvc.perform(get("/api/ride_request/admin?id=7"))
+                                .andExpect(status().is(404)); // logged, but no id exists
+        }
+
+        // Authorization tests for /api/ride_request?id={}
+
+        @Test
+        public void logged_out_users_cannot_get_any_by_id() throws Exception {
+                mockMvc.perform(get("/api/ride_request?id=7"))
+                                .andExpect(status().is(403)); // logged out users can't get by id
+        }
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void logged_in_users_cannot_get_by_id_in_simple_test() throws Exception {
+                mockMvc.perform(get("/api/ride_request?id=7"))
+                                .andExpect(status().is(404)); 
+                // logged in users can get their rides by id unless their ride matches, no ride with id 7 exists
+        }
+
+
+        // Authorization tests for /api/ride_request/post
+        // (Perhaps should also have these for put and delete)
+
+        @Test
+        public void logged_out_users_cannot_post() throws Exception {
+                mockMvc.perform(post("/api/ride_request/post"))
+                                .andExpect(status().is(403));
+        }
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void logged_in_regular_users_cannot_post() throws Exception {
+                mockMvc.perform(post("/api/ride_request/post"))
+                                .andExpect(status().is(403)); // only admins can post
+        }
+
+        // // Tests with mocks for database actions
+
+
+
+
+
+        // GET BY ID
+
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void test_that_logged_in_user_can_get_by_id_when_the_id_exists_and_user_id_matches() throws Exception {
+
+                // arrange
+
+                long userId = currentUserService.getCurrentUser().getUser().getId();
+
+                Ride ride = Ride.builder()
+                                .riderId(userId)
+                                .day("Monday")
+                                .course("CMPSC 156")
+                                .startTime("2:00PM")
+                                .endTime("3:15PM")
+                                .dropoffLocation("South Hall")
+                                .pickupLocation("Phelps Hall")
+                                .room("1431")
+                                .build();
+
+                when(rideRepository.findByIdAndRiderId(eq(7L), eq(userId))).thenReturn(Optional.of(ride));
+
+                // act
+                MvcResult response = mockMvc.perform(get("/api/ride_request?id=7"))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+
+                verify(rideRepository, times(1)).findByIdAndRiderId(eq(7L), eq(userId));
+                String expectedJson = mapper.writeValueAsString(ride);
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(expectedJson, responseString);
+        }
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void test_that_logged_in_user_can_get_by_id_when_the_id_does_not_exist() throws Exception {
+
+                // arrange
+
+                long userId = currentUserService.getCurrentUser().getUser().getId();
+
+                when(rideRepository.findByIdAndRiderId(eq(7L), eq(userId))).thenReturn(Optional.empty());
+
+                // act
+                MvcResult response = mockMvc.perform(get("/api/ride_request?id=7"))
+                                .andExpect(status().isNotFound()).andReturn();
+
+                // assert
+
+                verify(rideRepository, times(1)).findByIdAndRiderId(eq(7L), eq(userId));
+                Map<String, Object> json = responseToJson(response);
+                assertEquals("EntityNotFoundException", json.get("type"));
+                assertEquals("Ride with id 7 not found", json.get("message"));
+        }
+        
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void test_that_logged_in_user_can_get_by_id_when_the_id_exists_and_user_id_does_not_match() throws Exception {
+
+                // arrange
+
+                long userId = currentUserService.getCurrentUser().getUser().getId();
+                long otherUserId = userId + 1;
+
+                Ride ride = Ride.builder()
+                                .riderId(otherUserId)
+                                .day("Monday")
+                                .course("CMPSC 156")
+                                .startTime("2:00PM")
+                                .endTime("3:15PM")
+                                .dropoffLocation("South Hall")
+                                .pickupLocation("Phelps Hall")
+                                .room("1431")
+                                .build();
+
+                when(rideRepository.findByIdAndRiderId(eq(7L), eq(otherUserId))).thenReturn(Optional.of(ride));
+
+                // act
+                MvcResult response = mockMvc.perform(get("/api/ride_request?id=7"))
+                                .andExpect(status().isNotFound()).andReturn();
+
+                // assert
+
+                verify(rideRepository, times(1)).findByIdAndRiderId(eq(7L), eq(userId));
+                Map<String, Object> json = responseToJson(response);
+                assertEquals("EntityNotFoundException", json.get("type"));
+                assertEquals("Ride with id 7 not found", json.get("message"));
+        }
+
+
+
+        @WithMockUser(roles = { "ADMIN" , "USER" })
+        @Test
+        public void test_that_logged_in_admin_can_get_by_id_when_the_id_exists() throws Exception {
+
+                // arrange
+
+                long userId = currentUserService.getCurrentUser().getUser().getId();
+                long otherUserId = userId + 1;
+
+                Ride ride = Ride.builder()
+                                .riderId(otherUserId)
+                                .day("Monday")
+                                .course("CMPSC 156")
+                                .startTime("2:00PM")
+                                .endTime("3:15PM")
+                                .dropoffLocation("South Hall")
+                                .pickupLocation("Phelps Hall")
+                                .room("1431")
+                                .build();
+
+                when(rideRepository.findById(eq(7L))).thenReturn(Optional.of(ride));
+
+                // act
+                MvcResult response = mockMvc.perform(get("/api/ride_request/admin?id=7"))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+
+                verify(rideRepository, times(1)).findById(eq(7L));
+                String expectedJson = mapper.writeValueAsString(ride);
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(expectedJson, responseString);
+        }
+
+        @WithMockUser(roles = { "ADMIN" , "USER" })
+        @Test
+        public void test_that_logged_in_admin_can_get_by_id_when_the_id_does_not_exist() throws Exception {
+
+                // arrange
+
+                when(rideRepository.findById(eq(7L))).thenReturn(Optional.empty());
+
+                // act
+                MvcResult response = mockMvc.perform(get("/api/ride_request/admin?id=7"))
+                                .andExpect(status().isNotFound()).andReturn();
+
+                // assert
+
+                verify(rideRepository, times(1)).findById(eq(7L));
+                Map<String, Object> json = responseToJson(response);
+                assertEquals("EntityNotFoundException", json.get("type"));
+                assertEquals("Ride with id 7 not found", json.get("message"));
+        }
+        
+
+
+        // GET ALL
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void logged_in_user_can_get_all_their_own_rides() throws Exception {
+
+                long userId = currentUserService.getCurrentUser().getUser().getId();
+
+                Ride ride1 = Ride.builder()
+                                .riderId(userId)
+                                .day("Monday")
+                                .course("CMPSC 156")
+                                .startTime("2:00PM")
+                                .endTime("3:15PM")
+                                .dropoffLocation("South Hall")
+                                .pickupLocation("Phelps Hall")
+                                .room("1431")
+                                .build();
+
+                Ride ride3 = Ride.builder()
+                                .riderId(userId)
+                                .day("Thursday")
+                                .course("MATH 111C")
+                                .startTime("9:30AM")
+                                .endTime("10:45AM")
+                                .dropoffLocation("Phelps Hall")
+                                .pickupLocation("Student Resource Building")
+                                .room("3505")
+                                .build();
+
+                ArrayList<Ride> expectedRides = new ArrayList<>();
+                expectedRides.addAll(Arrays.asList(ride1, ride3));
+
+                when(rideRepository.findAllByRiderId(eq(userId))).thenReturn(expectedRides);
+
+                // act
+                MvcResult response = mockMvc.perform(get("/api/ride_request/all"))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+
+                verify(rideRepository, times(1)).findAllByRiderId(eq(userId));
+                String expectedJson = mapper.writeValueAsString(expectedRides);
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(expectedJson, responseString);
+        }
+
+        @WithMockUser(roles = { "ADMIN" , "USER" })
+        @Test
+        public void logged_in_admin_can_get_all_rides() throws Exception {
+
+                long userId = currentUserService.getCurrentUser().getUser().getId();
+                long otherUserId = userId + 1;
+
+                Ride ride1 = Ride.builder()
+                                .riderId(userId)
+                                .day("Monday")
+                                .course("CMPSC 156")
+                                .startTime("2:00PM")
+                                .endTime("3:15PM")
+                                .dropoffLocation("South Hall")
+                                .pickupLocation("Phelps Hall")
+                                .room("1431")
+                                .build();
+
+                Ride ride2 = Ride.builder()
+                                .riderId(otherUserId)
+                                .day("Thursday")
+                                .course("MATH 118C")
+                                .startTime("12:30PM")
+                                .endTime("1:45PM")
+                                .dropoffLocation("Phelps Hall")
+                                .pickupLocation("UCen")
+                                .room("3505")
+                                .build();
+
+                Ride ride3 = Ride.builder()
+                                .riderId(userId)
+                                .day("Thursday")
+                                .course("MATH 111C")
+                                .startTime("9:30AM")
+                                .endTime("10:45AM")
+                                .dropoffLocation("Phelps Hall")
+                                .pickupLocation("Student Resource Building")
+                                .room("3505")
+                                .build();
+
+                ArrayList<Ride> expectedRides = new ArrayList<>();
+                expectedRides.addAll(Arrays.asList(ride1, ride2, ride3));
+
+                when(rideRepository.findAll()).thenReturn(expectedRides);
+
+                // act
+                MvcResult response = mockMvc.perform(get("/api/ride_request/admin/all"))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+
+                verify(rideRepository, times(1)).findAll();
+                String expectedJson = mapper.writeValueAsString(expectedRides);
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(expectedJson, responseString);
+        }
+
+
+
+
+        // POST
+
+
+
+
+
+        // @WithMockUser(roles = { "ADMIN", "USER" })
+        // @Test
+        // public void an_admin_user_can_post_a_new_ride() throws Exception {
+        //         // arrange
+
+        //         Ride ride1 = Ride.builder()
+        //                 .day("Monday")
+        //                 .student("CGaucho")
+        //                 .course("CMPSC 156")
+        //                 .start("2:00PM")
+        //                 .end("3:15PM")
+        //                 .dropoff("South Hall")
+        //                 .room("1431")
+        //                 .pickup("Phelps Hall")
+        //                 .build();
+
+        //         when(rideRepository.save(eq(ride1))).thenReturn(ride1);
+
+        //         String postRequesString = "day=Monday&student=CGaucho&course=CMPSC 156&start=2:00PM&end=3:15PM&dropoff=South Hall&room=1431&pickup=Phelps Hall";
+
+        //         // act
+        //         MvcResult response = mockMvc.perform(
+        //                         post("/api/ride_request/post?" + postRequesString)
+        //                                         .with(csrf()))
+        //                         .andExpect(status().isOk()).andReturn();
+
+        //         // assert
+        //         verify(rideRepository, times(1)).save(ride1);
+        //         String expectedJson = mapper.writeValueAsString(ride1);
+        //         String responseString = response.getResponse().getContentAsString();
+        //         assertEquals(expectedJson, responseString);
+        // }
+}


### PR DESCRIPTION
Added Get/Post CRUD Operations for Ride Backend, with the following api:
`/ride_request?id={} `- get a ride with given id (returns ride object iff user_id matches for when user not admin/driver)
`/ride_request/all`- get all rides (of given user id if user is not admin/driver, else all)
`/ride_request/post` Create a ride request with the given parameters of a Ride object except riderId

Changed the Repository, Controller, and Controller Tests for the Ride Entity, following proj-courses PersonalSchedule entity as a guideline. Also changes ShiftRepository as a HotFix for maven backend.

An update of #46 that simplifies the paths for the frontend, swagger and tests still pass as expected:

https://github.com/ucsb-cs156-s23/proj-gauchoride-s23-5pm-4/assets/29584856/738dfe25-22c0-43e0-ab74-828db729aed5

Closes #45 and contributes to #7 
Closes #46