### PR TITLE
Anikait - Delete Operation for Rides, with combined path for all roles

### DIFF
--- a/src/main/java/edu/ucsb/cs156/gauchoride/controllers/RideController.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/controllers/RideController.java
@@ -32,7 +32,7 @@ public class RideController extends ApiController {
     @Autowired
     RideRepository rideRepository;
 
-    @ApiOperation(value = "List all rides, only users if not admin/driver")
+    @ApiOperation(value = "List all rides, only user's if not admin/driver")
     @PreAuthorize("hasRole('ROLE_ADMIN') || hasRole('ROLE_DRIVER') || hasRole('ROLE_USER')")
     @GetMapping("/all")
     public Iterable<Ride> allRidesForUser() {
@@ -48,7 +48,7 @@ public class RideController extends ApiController {
         return rides;
     }
 
-    @ApiOperation(value = "Get a single ride by id, only if users if not admin/driver")
+    @ApiOperation(value = "Get a single ride by id, only user's if not admin/driver")
     @PreAuthorize("hasRole('ROLE_ADMIN') || hasRole('ROLE_DRIVER') || hasRole('ROLE_USER')")
     @GetMapping("")
     public Ride getByIdForUser(
@@ -95,5 +95,26 @@ public class RideController extends ApiController {
         Ride savedRide = rideRepository.save(ride);
 
         return savedRide;
+    }
+
+    @ApiOperation(value = "Delete a ride, only user's if not admin/driver")
+    @PreAuthorize("hasRole('ROLE_ADMIN') || hasRole('ROLE_DRIVER') || hasRole('ROLE_USER')")
+    @DeleteMapping("")
+    public Object deleteRideForUser(
+            @ApiParam("id") @RequestParam Long id) {
+
+        Ride ride;
+
+        if (getCurrentUser().getRoles().contains(new SimpleGrantedAuthority("ROLE_ADMIN")) ||
+            getCurrentUser().getRoles().contains(new SimpleGrantedAuthority("ROLE_DRIVER"))) {
+            ride = rideRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(Ride.class, id));;
+        } else {
+            ride = rideRepository.findByIdAndRiderId(id, getCurrentUser().getUser().getId())
+                .orElseThrow(() -> new EntityNotFoundException(Ride.class, id));
+        }
+
+        rideRepository.delete(ride);
+        return genericMessage("Ride with id %s deleted".formatted(id));
     }
 }

--- a/src/main/java/edu/ucsb/cs156/gauchoride/controllers/RideController.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/controllers/RideController.java
@@ -52,7 +52,9 @@ public class RideController extends ApiController {
     @PreAuthorize("hasRole('ROLE_ADMIN') || hasRole('ROLE_DRIVER') || hasRole('ROLE_USER')")
     @GetMapping("")
     public Ride getByIdForUser(
-            @ApiParam("id") @RequestParam Long id) {
+            @ApiParam(name="id", type="long", value = "Id of the Ride", 
+            required = true)  
+            @RequestParam Long id) {
         Ride ride;
         
         if (getCurrentUser().getRoles().contains(new SimpleGrantedAuthority("ROLE_ADMIN")) ||
@@ -71,13 +73,27 @@ public class RideController extends ApiController {
     @PreAuthorize("hasRole('ROLE_USER')")
     @PostMapping("/post")
     public Ride postRide(
-        @ApiParam("day") @RequestParam String day,
-        @ApiParam("startTime") @RequestParam String startTime,
-        @ApiParam("endTime") @RequestParam String endTime,
-        @ApiParam("pickupLocation") @RequestParam String pickupLocation,
-        @ApiParam("dropoffLocation") @RequestParam String dropoffLocation,
-        @ApiParam("room") @RequestParam String room,
-        @ApiParam("course") @RequestParam String course
+        @ApiParam(name="day", type="String", value = "Day of the week ride is requested (Monday - Sunday)", example="Tuesday", 
+                    required = true, allowableValues = "Monday, Tuesday, Wednesday, Thursday, Friday, Saturday, Sunday") 
+        @RequestParam String day,
+
+        @ApiParam(name="startTime", type="String", value = "Time the ride starts HH:MM(A/P)M", example="12:30AM", required = true)
+        @RequestParam String startTime,
+
+        @ApiParam(name="endTime", type="String", value = "Time the ride ends HH:MM(A/P)M", example="12:30AM", required = true)
+        @RequestParam String endTime,
+
+        @ApiParam(name="pickupLocation", type="String", value = "Location the ride starts", example="Phelps Hall", required = true)
+        @RequestParam String pickupLocation,
+
+        @ApiParam(name="dropoffLocation", type="String", value = "Location the ride ends", example="South Hall", required = true)
+        @RequestParam String dropoffLocation,
+
+        @ApiParam(name="room", type="String", value = "Room number for the dropoffLocation", example="1431", required = true)
+        @RequestParam String room,
+
+        @ApiParam(name="course", type="String", value = "Course number for the class at the dropoffLocation", example="CMPSC 156", required = true)
+        @RequestParam String course
         )
         {
 

--- a/src/main/java/edu/ucsb/cs156/gauchoride/controllers/RideController.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/controllers/RideController.java
@@ -35,7 +35,7 @@ public class RideController extends ApiController {
     @ApiOperation(value = "List all rides, only user's if not admin/driver")
     @PreAuthorize("hasRole('ROLE_ADMIN') || hasRole('ROLE_DRIVER') || hasRole('ROLE_USER')")
     @GetMapping("/all")
-    public Iterable<Ride> allRidesForUser() {
+    public Iterable<Ride> allRides() {
         Iterable<Ride> rides;
 
         if (getCurrentUser().getRoles().contains(new SimpleGrantedAuthority("ROLE_ADMIN")) ||
@@ -51,8 +51,8 @@ public class RideController extends ApiController {
     @ApiOperation(value = "Get a single ride by id, only user's if not admin/driver")
     @PreAuthorize("hasRole('ROLE_ADMIN') || hasRole('ROLE_DRIVER') || hasRole('ROLE_USER')")
     @GetMapping("")
-    public Ride getByIdForUser(
-            @ApiParam(name="id", type="long", value = "Id of the Ride", 
+    public Ride getById(
+            @ApiParam(name="id", type="long", value = "Id of the Ride to get", 
             required = true)  
             @RequestParam Long id) {
         Ride ride;
@@ -116,8 +116,10 @@ public class RideController extends ApiController {
     @ApiOperation(value = "Delete a ride, only user's if not admin/driver")
     @PreAuthorize("hasRole('ROLE_ADMIN') || hasRole('ROLE_DRIVER') || hasRole('ROLE_USER')")
     @DeleteMapping("")
-    public Object deleteRideForUser(
-            @ApiParam("id") @RequestParam Long id) {
+    public Object deleteRide(
+        @ApiParam(name="id", type="long", value = "Id of the Ride to be deleted", 
+        required = true)
+        @RequestParam Long id) {
 
         Ride ride;
 

--- a/src/test/java/edu/ucsb/cs156/gauchoride/controllers/RideControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/gauchoride/controllers/RideControllerTests.java
@@ -113,6 +113,14 @@ public class RideControllerTests extends ControllerTestCase {
                                 .andExpect(status().is(403));
         }
 
+        // Authorization tests for delete /api/ride_request
+
+        @Test
+         public void logged_out_users_cannot_delete() throws Exception {
+                 mockMvc.perform(delete("/api/ride_request?id=9"))
+                                 .andExpect(status().is(403));
+        }
+
         // // Tests with mocks for database actions
 
 

--- a/src/test/java/edu/ucsb/cs156/gauchoride/controllers/RideControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/gauchoride/controllers/RideControllerTests.java
@@ -523,4 +523,212 @@ public class RideControllerTests extends ControllerTestCase {
                 String responseString = response.getResponse().getContentAsString();
                 assertEquals(expectedJson, responseString);
         }
+
+
+        
+
+
+        // DELETE
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void user_can_delete_their_own_ride() throws Exception {
+                // arrange
+
+                long userId = currentUserService.getCurrentUser().getUser().getId();
+
+                Ride ride1 = Ride.builder()
+                        .riderId(userId)
+                        .day("Monday")
+                        .course("CMPSC 156")
+                        .startTime("2:00PM")
+                        .endTime("3:15PM")
+                        .dropoffLocation("South Hall")
+                        .pickupLocation("Phelps Hall")
+                        .room("1431")
+                        .build();
+
+                when(rideRepository.findByIdAndRiderId(eq(15L), eq(userId))).thenReturn(Optional.of(ride1));
+
+                // act
+                MvcResult response = mockMvc.perform(
+                                delete("/api/ride_request?id=15")
+                                                .with(csrf()))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assertuserId
+                verify(rideRepository, times(1)).findByIdAndRiderId(eq(15L), eq(userId));
+                verify(rideRepository, times(1)).delete(ride1);
+
+                Map<String, Object> json = responseToJson(response);
+                assertEquals("Ride with id 15 deleted", json.get("message"));
+        }
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void user_tries_to_delete_other_users_ride_and_fails()
+                        throws Exception {
+                // arrange
+
+                long userId = currentUserService.getCurrentUser().getUser().getId();
+                long otherUserId = userId + 1;
+
+                Ride ride1 = Ride.builder()
+                        .riderId(otherUserId)
+                        .day("Monday")
+                        .course("CMPSC 156")
+                        .startTime("2:00PM")
+                        .endTime("3:15PM")
+                        .dropoffLocation("South Hall")
+                        .pickupLocation("Phelps Hall")
+                        .room("1431")
+                        .build();
+
+                when(rideRepository.findByIdAndRiderId(eq(15L), eq(otherUserId))).thenReturn(Optional.of(ride1));
+
+                // act
+                MvcResult response = mockMvc.perform(
+                                delete("/api/ride_request?id=15")
+                                                .with(csrf()))
+                                .andExpect(status().isNotFound()).andReturn();
+
+                // assert
+                verify(rideRepository, times(1)).findByIdAndRiderId(eq(15L), eq(userId));
+                Map<String, Object> json = responseToJson(response);
+                assertEquals("Ride with id 15 not found", json.get("message"));
+        }
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void user_tries_to_delete_non_existant_ride_and_gets_right_error_message()
+                        throws Exception {
+                // arrange
+
+                long userId = currentUserService.getCurrentUser().getUser().getId();
+
+                when(rideRepository.findByIdAndRiderId(eq(15L), eq(userId))).thenReturn(Optional.empty());
+
+                // act
+                MvcResult response = mockMvc.perform(
+                                delete("/api/ride_request?id=15")
+                                                .with(csrf()))
+                                .andExpect(status().isNotFound()).andReturn();
+
+                // assert
+                verify(rideRepository, times(1)).findByIdAndRiderId(eq(15L), eq(userId));
+                Map<String, Object> json = responseToJson(response);
+                assertEquals("Ride with id 15 not found", json.get("message"));
+        }
+
+
+        @WithMockUser(roles = { "ADMIN", "USER" })
+        @Test
+        public void admin_can_delete_any_ride() throws Exception {
+                // arrange
+
+                long userId = currentUserService.getCurrentUser().getUser().getId();
+                long otherUserId = userId + 1;
+
+                Ride ride1 = Ride.builder()
+                        .riderId(otherUserId)
+                        .day("Monday")
+                        .course("CMPSC 156")
+                        .startTime("2:00PM")
+                        .endTime("3:15PM")
+                        .dropoffLocation("South Hall")
+                        .pickupLocation("Phelps Hall")
+                        .room("1431")
+                        .build();
+
+                when(rideRepository.findById(eq(15L))).thenReturn(Optional.of(ride1));
+
+                // act
+                MvcResult response = mockMvc.perform(
+                                delete("/api/ride_request?id=15")
+                                                .with(csrf()))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+                verify(rideRepository, times(1)).findById(15L);
+                verify(rideRepository, times(1)).delete(ride1);
+
+                Map<String, Object> json = responseToJson(response);
+                assertEquals("Ride with id 15 deleted", json.get("message"));
+        }
+
+        @WithMockUser(roles = { "DRIVER" })
+        @Test
+        public void driver_can_delete_any_ride() throws Exception {
+                // arrange
+
+                long userId = currentUserService.getCurrentUser().getUser().getId();
+                long otherUserId = userId + 1;
+
+                Ride ride1 = Ride.builder()
+                        .riderId(otherUserId)
+                        .day("Monday")
+                        .course("CMPSC 156")
+                        .startTime("2:00PM")
+                        .endTime("3:15PM")
+                        .dropoffLocation("South Hall")
+                        .pickupLocation("Phelps Hall")
+                        .room("1431")
+                        .build();
+
+                when(rideRepository.findById(eq(15L))).thenReturn(Optional.of(ride1));
+
+                // act
+                MvcResult response = mockMvc.perform(
+                                delete("/api/ride_request?id=15")
+                                                .with(csrf()))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+                verify(rideRepository, times(1)).findById(15L);
+                verify(rideRepository, times(1)).delete(ride1);
+
+                Map<String, Object> json = responseToJson(response);
+                assertEquals("Ride with id 15 deleted", json.get("message"));
+        }
+
+        @WithMockUser(roles = { "ADMIN", "USER" })
+        @Test
+        public void admin_tries_to_delete_non_existant_ride_and_gets_right_error_message()
+                        throws Exception {
+                // arrange
+
+                when(rideRepository.findById(eq(15L))).thenReturn(Optional.empty());
+
+                // act
+                MvcResult response = mockMvc.perform(
+                                delete("/api/ride_request?id=15")
+                                                .with(csrf()))
+                                .andExpect(status().isNotFound()).andReturn();
+
+                // assert
+                verify(rideRepository, times(1)).findById(15L);
+                Map<String, Object> json = responseToJson(response);
+                assertEquals("Ride with id 15 not found", json.get("message"));
+        }
+
+
+        @WithMockUser(roles = { "DRIVER" })
+        @Test
+        public void driver_tries_to_delete_non_existant_ride_and_gets_right_error_message()
+                        throws Exception {
+                // arrange
+
+                when(rideRepository.findById(eq(15L))).thenReturn(Optional.empty());
+
+                // act
+                MvcResult response = mockMvc.perform(
+                                delete("/api/ride_request?id=15")
+                                                .with(csrf()))
+                                .andExpect(status().isNotFound()).andReturn();
+
+                // assert
+                verify(rideRepository, times(1)).findById(15L);
+                Map<String, Object> json = responseToJson(response);
+                assertEquals("Ride with id 15 not found", json.get("message"));
+        }
 }


### PR DESCRIPTION
Added Delete CRUD Operations for Ride Backend, with the following api:
`/ride_request?id={}` - delete a ride with given id (deletes ride object iff user_id matches for when user not admin/driver)

Builds off #49 (Needs to be reviewed first!), only change is adding the delete endpoint and testing it.

Works as expected on swagger:

https://github.com/ucsb-cs156-s23/proj-gauchoride-s23-5pm-4/assets/29584856/598d9ebd-4e93-4acb-86d1-8ae32d4a2722

