### PR TITLE
Anikait - Edit Operation for Rides, with combined path for all roles

### DIFF
--- a/src/main/java/edu/ucsb/cs156/gauchoride/controllers/RideController.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/controllers/RideController.java
@@ -141,7 +141,9 @@ public class RideController extends ApiController {
     @PreAuthorize("hasRole('ROLE_ADMIN') || hasRole('ROLE_DRIVER') || hasRole('ROLE_USER')")
     @PutMapping("")
     public Ride updateRide(
-            @ApiParam("id") @RequestParam Long id,
+            @ApiParam(name="id", type="long", value = "Id of the Ride to be deleted", 
+            required = true)
+            @RequestParam Long id,
             @RequestBody @Valid Ride incoming) {
 
         Ride ride;

--- a/src/main/java/edu/ucsb/cs156/gauchoride/controllers/RideController.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/controllers/RideController.java
@@ -117,4 +117,36 @@ public class RideController extends ApiController {
         rideRepository.delete(ride);
         return genericMessage("Ride with id %s deleted".formatted(id));
     }
+
+
+    @ApiOperation(value = "Update a single ride, only user's if not admin/driver")
+    @PreAuthorize("hasRole('ROLE_ADMIN') || hasRole('ROLE_DRIVER') || hasRole('ROLE_USER')")
+    @PutMapping("")
+    public Ride updateRide(
+            @ApiParam("id") @RequestParam Long id,
+            @RequestBody @Valid Ride incoming) {
+
+        Ride ride;
+
+        if (getCurrentUser().getRoles().contains(new SimpleGrantedAuthority("ROLE_ADMIN")) ||
+            getCurrentUser().getRoles().contains(new SimpleGrantedAuthority("ROLE_DRIVER"))) {
+            ride = rideRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(Ride.class, id));;
+        } else {
+            ride = rideRepository.findByIdAndRiderId(id, getCurrentUser().getUser().getId())
+                .orElseThrow(() -> new EntityNotFoundException(Ride.class, id));
+        }
+
+        ride.setDay(incoming.getDay());
+        ride.setStartTime(incoming.getStartTime());
+        ride.setEndTime(incoming.getEndTime());
+        ride.setPickupLocation(incoming.getPickupLocation());
+        ride.setDropoffLocation(incoming.getDropoffLocation());
+        ride.setRoom(incoming.getRoom());
+        ride.setCourse(incoming.getCourse());
+
+        rideRepository.save(ride);
+
+        return ride;
+    }
 }

--- a/src/main/java/edu/ucsb/cs156/gauchoride/controllers/RideController.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/controllers/RideController.java
@@ -52,7 +52,9 @@ public class RideController extends ApiController {
     @PreAuthorize("hasRole('ROLE_ADMIN') || hasRole('ROLE_DRIVER') || hasRole('ROLE_USER')")
     @GetMapping("")
     public Ride getByIdForUser(
-            @ApiParam("id") @RequestParam Long id) {
+            @ApiParam(name="id", type="long", value = "Id of the Ride", 
+            required = true)  
+            @RequestParam Long id) {
         Ride ride;
         
         if (getCurrentUser().getRoles().contains(new SimpleGrantedAuthority("ROLE_ADMIN")) ||
@@ -71,13 +73,27 @@ public class RideController extends ApiController {
     @PreAuthorize("hasRole('ROLE_USER')")
     @PostMapping("/post")
     public Ride postRide(
-        @ApiParam("day") @RequestParam String day,
-        @ApiParam("startTime") @RequestParam String startTime,
-        @ApiParam("endTime") @RequestParam String endTime,
-        @ApiParam("pickupLocation") @RequestParam String pickupLocation,
-        @ApiParam("dropoffLocation") @RequestParam String dropoffLocation,
-        @ApiParam("room") @RequestParam String room,
-        @ApiParam("course") @RequestParam String course
+        @ApiParam(name="day", type="String", value = "Day of the week ride is requested (Monday - Sunday)", example="Tuesday", 
+                    required = true, allowableValues = "Monday, Tuesday, Wednesday, Thursday, Friday, Saturday, Sunday") 
+        @RequestParam String day,
+
+        @ApiParam(name="startTime", type="String", value = "Time the ride starts HH:MM(A/P)M", example="12:30AM", required = true)
+        @RequestParam String startTime,
+
+        @ApiParam(name="endTime", type="String", value = "Time the ride ends HH:MM(A/P)M", example="12:30AM", required = true)
+        @RequestParam String endTime,
+
+        @ApiParam(name="pickupLocation", type="String", value = "Location the ride starts", example="Phelps Hall", required = true)
+        @RequestParam String pickupLocation,
+
+        @ApiParam(name="dropoffLocation", type="String", value = "Location the ride ends", example="South Hall", required = true)
+        @RequestParam String dropoffLocation,
+
+        @ApiParam(name="room", type="String", value = "Room number for the dropoffLocation", example="1431", required = true)
+        @RequestParam String room,
+
+        @ApiParam(name="course", type="String", value = "Course number for the class at the dropoffLocation", example="CMPSC 156", required = true)
+        @RequestParam String course
         )
         {
 

--- a/src/main/java/edu/ucsb/cs156/gauchoride/controllers/RideController.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/controllers/RideController.java
@@ -141,7 +141,7 @@ public class RideController extends ApiController {
     @PreAuthorize("hasRole('ROLE_ADMIN') || hasRole('ROLE_DRIVER') || hasRole('ROLE_USER')")
     @PutMapping("")
     public Ride updateRide(
-            @ApiParam(name="id", type="long", value = "Id of the Ride to be deleted", 
+            @ApiParam(name="id", type="long", value = "Id of the Ride to be edited", 
             required = true)
             @RequestParam Long id,
             @RequestBody @Valid Ride incoming) {

--- a/src/main/java/edu/ucsb/cs156/gauchoride/controllers/RideController.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/controllers/RideController.java
@@ -35,7 +35,7 @@ public class RideController extends ApiController {
     @ApiOperation(value = "List all rides, only user's if not admin/driver")
     @PreAuthorize("hasRole('ROLE_ADMIN') || hasRole('ROLE_DRIVER') || hasRole('ROLE_USER')")
     @GetMapping("/all")
-    public Iterable<Ride> allRidesForUser() {
+    public Iterable<Ride> allRides() {
         Iterable<Ride> rides;
 
         if (getCurrentUser().getRoles().contains(new SimpleGrantedAuthority("ROLE_ADMIN")) ||
@@ -51,8 +51,8 @@ public class RideController extends ApiController {
     @ApiOperation(value = "Get a single ride by id, only user's if not admin/driver")
     @PreAuthorize("hasRole('ROLE_ADMIN') || hasRole('ROLE_DRIVER') || hasRole('ROLE_USER')")
     @GetMapping("")
-    public Ride getByIdForUser(
-            @ApiParam(name="id", type="long", value = "Id of the Ride", 
+    public Ride getById(
+            @ApiParam(name="id", type="long", value = "Id of the Ride to get", 
             required = true)  
             @RequestParam Long id) {
         Ride ride;
@@ -116,8 +116,10 @@ public class RideController extends ApiController {
     @ApiOperation(value = "Delete a ride, only user's if not admin/driver")
     @PreAuthorize("hasRole('ROLE_ADMIN') || hasRole('ROLE_DRIVER') || hasRole('ROLE_USER')")
     @DeleteMapping("")
-    public Object deleteRideForUser(
-            @ApiParam("id") @RequestParam Long id) {
+    public Object deleteRide(
+        @ApiParam(name="id", type="long", value = "Id of the Ride to be deleted", 
+        required = true)
+        @RequestParam Long id) {
 
         Ride ride;
 

--- a/src/test/java/edu/ucsb/cs156/gauchoride/controllers/RideControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/gauchoride/controllers/RideControllerTests.java
@@ -113,6 +113,14 @@ public class RideControllerTests extends ControllerTestCase {
                                 .andExpect(status().is(403));
         }
 
+        // Authorization tests for delete /api/ride_request
+
+        @Test
+         public void logged_out_users_cannot_delete() throws Exception {
+                 mockMvc.perform(delete("/api/ride_request?id=9"))
+                                 .andExpect(status().is(403));
+        }
+
         // // Tests with mocks for database actions
 
 

--- a/src/test/java/edu/ucsb/cs156/gauchoride/controllers/RideControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/gauchoride/controllers/RideControllerTests.java
@@ -121,6 +121,14 @@ public class RideControllerTests extends ControllerTestCase {
                                  .andExpect(status().is(403));
         }
 
+        // Authorization tests for put /api/ride_request
+
+        @Test
+         public void logged_out_users_cannot_edit() throws Exception {
+                 mockMvc.perform(put("/api/ride_request?id=9"))
+                                 .andExpect(status().is(403));
+        }
+
         // // Tests with mocks for database actions
 
 
@@ -738,5 +746,323 @@ public class RideControllerTests extends ControllerTestCase {
                 verify(rideRepository, times(1)).findById(15L);
                 Map<String, Object> json = responseToJson(response);
                 assertEquals("Ride with id 15 not found", json.get("message"));
+        }
+
+
+
+
+        // EDIT
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void user_can_edit_their_own_ride() throws Exception {
+                // arrange
+
+                long userId = currentUserService.getCurrentUser().getUser().getId();
+
+                Ride ride_original = Ride.builder()
+                                .riderId(userId)
+                                .day("Monday")
+                                .course("CMPSC 156")
+                                .startTime("2:00PM")
+                                .endTime("3:15PM")
+                                .dropoffLocation("South Hall")
+                                .pickupLocation("Phelps Hall")
+                                .room("1431")
+                                .build();
+
+                Ride ride_edited = Ride.builder()
+                                .riderId(userId)
+                                .day("Thursday")
+                                .course("MATH 118C")
+                                .startTime("12:30PM")
+                                .endTime("1:45PM")
+                                .dropoffLocation("Phelps Hall")
+                                .pickupLocation("UCen")
+                                .room("3505")
+                                .build();
+
+                String requestBody = mapper.writeValueAsString(ride_edited);
+
+                when(rideRepository.findByIdAndRiderId(eq(67L), eq(userId))).thenReturn(Optional.of(ride_original));
+
+                // act
+                MvcResult response = mockMvc.perform(
+                                put("/api/ride_request?id=67")
+                                                .contentType(MediaType.APPLICATION_JSON)
+                                                .characterEncoding("utf-8")
+                                                .content(requestBody)
+                                                .with(csrf()))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+                verify(rideRepository, times(1)).findByIdAndRiderId(eq(67L), eq(userId));
+                verify(rideRepository, times(1)).save(ride_edited); // should be saved with correct user
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(requestBody, responseString);
+        }
+
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void user_canot_edit_other_users_ride() throws Exception {
+                // arrange
+
+                long userId = currentUserService.getCurrentUser().getUser().getId();
+                long otherUserId = userId + 1;
+
+                Ride ride_original = Ride.builder()
+                                .riderId(otherUserId)
+                                .day("Monday")
+                                .course("CMPSC 156")
+                                .startTime("2:00PM")
+                                .endTime("3:15PM")
+                                .dropoffLocation("South Hall")
+                                .pickupLocation("Phelps Hall")
+                                .room("1431")
+                                .build();
+
+                Ride ride_edited = Ride.builder()
+                                .riderId(otherUserId)
+                                .day("Thursday")
+                                .course("MATH 118C")
+                                .startTime("12:30PM")
+                                .endTime("1:45PM")
+                                .dropoffLocation("Phelps Hall")
+                                .pickupLocation("UCen")
+                                .room("3505")
+                                .build();
+
+                String requestBody = mapper.writeValueAsString(ride_edited);
+
+                when(rideRepository.findByIdAndRiderId(eq(67L), eq(otherUserId))).thenReturn(Optional.of(ride_original));
+
+                // act
+                MvcResult response = mockMvc.perform(
+                                put("/api/ride_request?id=67")
+                                                .contentType(MediaType.APPLICATION_JSON)
+                                                .characterEncoding("utf-8")
+                                                .content(requestBody)
+                                                .with(csrf()))
+                                .andExpect(status().isNotFound()).andReturn();
+
+                // assert
+                verify(rideRepository, times(1)).findByIdAndRiderId(eq(67L), eq(userId));
+                Map<String, Object> json = responseToJson(response);
+                assertEquals("Ride with id 67 not found", json.get("message"));
+        }
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void user_cannot_edit_ride_that_does_not_exist() throws Exception {
+                // arrange
+
+                long userId = currentUserService.getCurrentUser().getUser().getId();
+
+                Ride ride_edited = Ride.builder()
+                                .riderId(userId)
+                                .day("Thursday")
+                                .course("MATH 118C")
+                                .startTime("12:30PM")
+                                .endTime("1:45PM")
+                                .dropoffLocation("Phelps Hall")
+                                .pickupLocation("UCen")
+                                .room("3505")
+                                .build();
+
+
+                String requestBody = mapper.writeValueAsString(ride_edited);
+
+                when(rideRepository.findByIdAndRiderId(eq(67L), eq(userId))).thenReturn(Optional.empty());
+
+                // act
+                MvcResult response = mockMvc.perform(
+                                put("/api/ride_request?id=67")
+                                                .contentType(MediaType.APPLICATION_JSON)
+                                                .characterEncoding("utf-8")
+                                                .content(requestBody)
+                                                .with(csrf()))
+                                .andExpect(status().isNotFound()).andReturn();
+
+                // assert
+                verify(rideRepository, times(1)).findByIdAndRiderId(67L, userId);
+                Map<String, Object> json = responseToJson(response);
+                assertEquals("Ride with id 67 not found", json.get("message"));
+
+        }
+
+
+        @WithMockUser(roles = { "ADMIN", "USER" })
+        @Test
+        public void admin_can_edit_an_existing_ride() throws Exception {
+                // arrange
+
+                long userId = currentUserService.getCurrentUser().getUser().getId();
+                long otherUserId = userId + 1;
+
+                Ride ride_original = Ride.builder()
+                                .riderId(otherUserId)
+                                .day("Monday")
+                                .course("CMPSC 156")
+                                .startTime("2:00PM")
+                                .endTime("3:15PM")
+                                .dropoffLocation("South Hall")
+                                .pickupLocation("Phelps Hall")
+                                .room("1431")
+                                .build();
+
+                Ride ride_edited = Ride.builder()
+                                .riderId(otherUserId)
+                                .day("Thursday")
+                                .course("MATH 118C")
+                                .startTime("12:30PM")
+                                .endTime("1:45PM")
+                                .dropoffLocation("Phelps Hall")
+                                .pickupLocation("UCen")
+                                .room("3505")
+                                .build();
+
+                String requestBody = mapper.writeValueAsString(ride_edited);
+
+                when(rideRepository.findById(eq(67L))).thenReturn(Optional.of(ride_original));
+
+                // act
+                MvcResult response = mockMvc.perform(
+                                put("/api/ride_request?id=67")
+                                                .contentType(MediaType.APPLICATION_JSON)
+                                                .characterEncoding("utf-8")
+                                                .content(requestBody)
+                                                .with(csrf()))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+                verify(rideRepository, times(1)).findById(67L);
+                verify(rideRepository, times(1)).save(ride_edited); // should be saved with correct user
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(requestBody, responseString);
+        }
+
+        @WithMockUser(roles = { "DRIVER" })
+        @Test
+        public void driver_can_edit_an_existing_ride() throws Exception {
+                // arrange
+
+                long userId = currentUserService.getCurrentUser().getUser().getId();
+                long otherUserId = userId + 1;
+
+                Ride ride_original = Ride.builder()
+                                .riderId(otherUserId)
+                                .day("Monday")
+                                .course("CMPSC 156")
+                                .startTime("2:00PM")
+                                .endTime("3:15PM")
+                                .dropoffLocation("South Hall")
+                                .pickupLocation("Phelps Hall")
+                                .room("1431")
+                                .build();
+
+                Ride ride_edited = Ride.builder()
+                                .riderId(otherUserId)
+                                .day("Thursday")
+                                .course("MATH 118C")
+                                .startTime("12:30PM")
+                                .endTime("1:45PM")
+                                .dropoffLocation("Phelps Hall")
+                                .pickupLocation("UCen")
+                                .room("3505")
+                                .build();
+
+                String requestBody = mapper.writeValueAsString(ride_edited);
+
+                when(rideRepository.findById(eq(67L))).thenReturn(Optional.of(ride_original));
+
+                // act
+                MvcResult response = mockMvc.perform(
+                                put("/api/ride_request?id=67")
+                                                .contentType(MediaType.APPLICATION_JSON)
+                                                .characterEncoding("utf-8")
+                                                .content(requestBody)
+                                                .with(csrf()))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+                verify(rideRepository, times(1)).findById(67L);
+                verify(rideRepository, times(1)).save(ride_edited); // should be saved with correct user
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(requestBody, responseString);
+        }
+
+        @WithMockUser(roles = { "ADMIN", "USER" })
+        @Test
+        public void admin_cannot_edit_ride_that_does_not_exist() throws Exception {
+                // arrange
+
+                long userId = currentUserService.getCurrentUser().getUser().getId();
+
+                Ride ride_edited = Ride.builder()
+                                .riderId(userId)
+                                .day("Thursday")
+                                .course("MATH 118C")
+                                .startTime("12:30PM")
+                                .endTime("1:45PM")
+                                .dropoffLocation("Phelps Hall")
+                                .pickupLocation("UCen")
+                                .room("3505")
+                                .build();
+
+                String requestBody = mapper.writeValueAsString(ride_edited);
+
+                when(rideRepository.findById(eq(67L))).thenReturn(Optional.empty());
+
+                // act
+                MvcResult response = mockMvc.perform(
+                                put("/api/ride_request?id=67")
+                                                .contentType(MediaType.APPLICATION_JSON)
+                                                .characterEncoding("utf-8")
+                                                .content(requestBody)
+                                                .with(csrf()))
+                                .andExpect(status().isNotFound()).andReturn();
+
+                // assert
+                verify(rideRepository, times(1)).findById(67L);
+                Map<String, Object> json = responseToJson(response);
+                assertEquals("Ride with id 67 not found", json.get("message"));
+        }
+
+        @WithMockUser(roles = { "DRIVER" })
+        @Test
+        public void driver_cannot_edit_ride_that_does_not_exist() throws Exception {
+                // arrange
+
+                long userId = currentUserService.getCurrentUser().getUser().getId();
+
+                Ride ride_edited = Ride.builder()
+                                .riderId(userId)
+                                .day("Thursday")
+                                .course("MATH 118C")
+                                .startTime("12:30PM")
+                                .endTime("1:45PM")
+                                .dropoffLocation("Phelps Hall")
+                                .pickupLocation("UCen")
+                                .room("3505")
+                                .build();
+
+                String requestBody = mapper.writeValueAsString(ride_edited);
+
+                when(rideRepository.findById(eq(67L))).thenReturn(Optional.empty());
+
+                // act
+                MvcResult response = mockMvc.perform(
+                                put("/api/ride_request?id=67")
+                                                .contentType(MediaType.APPLICATION_JSON)
+                                                .characterEncoding("utf-8")
+                                                .content(requestBody)
+                                                .with(csrf()))
+                                .andExpect(status().isNotFound()).andReturn();
+
+                // assert
+                verify(rideRepository, times(1)).findById(67L);
+                Map<String, Object> json = responseToJson(response);
+                assertEquals("Ride with id 67 not found", json.get("message"));
         }
 }


### PR DESCRIPTION
Added Put CRUD Operations for Ride Backend, with the following api:
`/ride_request?id={}&riderId=...` - edit a ride with given id (edits ride object iff user_id matches for when user not admin/driver)

Builds off #53 (Needs to be reviewed first!), only change is adding the edit endpoint and testing it.
