### PR TITLE
Ameymwalimbe shift get post

### DIFF
--- a/src/main/java/edu/ucsb/cs156/gauchoride/controllers/ShiftController.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/controllers/ShiftController.java
@@ -1,0 +1,85 @@
+package edu.ucsb.cs156.gauchoride.controllers;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import edu.ucsb.cs156.gauchoride.entities.Shift;
+import edu.ucsb.cs156.gauchoride.repositories.ShiftRepository;
+import edu.ucsb.cs156.gauchoride.repositories.UserRepository;
+import edu.ucsb.cs156.gauchoride.errors.EntityNotFoundException;
+import edu.ucsb.cs156.gauchoride.models.CurrentUser;
+
+import java.time.LocalTime;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+
+
+@Api(description = "Shift information")
+@RequestMapping("/api/shift")
+@RestController
+public class ShiftController extends ApiController {
+    @Autowired
+    ShiftRepository shiftRepository;
+
+    @Autowired
+    ObjectMapper mapper;
+
+    @ApiOperation(value = "Get a list of all shifts")
+    @PreAuthorize("hasRole('ROLE_ADMIN') || hasRole('ROLE_DRIVER') || hasRole('ROLE_USER')")
+    @GetMapping("/all")
+    public ResponseEntity<String> allShifts()
+            throws JsonProcessingException {
+        Iterable<Shift> shifts = shiftRepository.findAll();
+        String body = mapper.writeValueAsString(shifts);
+        return ResponseEntity.ok().body(body);
+    }
+
+    @ApiOperation(value = "Get shift by id")
+    @PreAuthorize("hasRole('ROLE_ADMIN') || hasRole('ROLE_DRIVER') || hasRole('ROLE_USER')")
+    @GetMapping("/get")
+    public Shift shiftByID(
+            @ApiParam(name = "id", type = "Long", value = "id number of shift to get", example = "1", required = true) @RequestParam Long id)
+            throws JsonProcessingException {
+        Shift shift = shiftRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(Shift.class, id));
+        return shift;
+    }
+
+    @ApiOperation(value = "Create a new shift for the table")
+    @PreAuthorize("hasRole('ROLE_DRIVER')")
+    @PostMapping("/post")
+    public Shift postShift(
+        @ApiParam("day") @RequestParam String day,
+        @ApiParam("shiftStart") @RequestParam String shiftStart,
+        @ApiParam("shiftEnd") @RequestParam String shiftEnd,
+        @ApiParam("driverID") @RequestParam long driverID ,
+        @ApiParam("driverBackupID") @RequestParam long driverBackupID
+        )
+        {
+
+        Shift shift = new Shift();
+
+        shift.setDriverID(getCurrentUser().getUser().getId());
+        shift.setDay(day);
+        shift.setShiftStart(shiftStart);
+        shift.setShiftEnd(shiftEnd);
+        shift.setDriverBackupID(driverBackupID);
+
+        Shift savedShift = shiftRepository.save(shift);
+
+        return savedShift;
+    }
+}

--- a/src/main/java/edu/ucsb/cs156/gauchoride/controllers/ShiftController.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/controllers/ShiftController.java
@@ -59,7 +59,7 @@ public class ShiftController extends ApiController {
     }
 
     @ApiOperation(value = "Create a new shift for the table")
-    @PreAuthorize("hasRole('ROLE_DRIVER')")
+    @PreAuthorize("hasRole('ROLE_ADMIN') || hasRole('ROLE_DRIVER')")
     @PostMapping("/post")
     public Shift postShift(
         @ApiParam("day") @RequestParam String day,

--- a/src/main/java/edu/ucsb/cs156/gauchoride/entities/Shift.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/entities/Shift.java
@@ -23,9 +23,9 @@ public class Shift {
   @ApiModelProperty(allowableValues = "Monday, Tuesday, Wednesday, Thursday, Friday, Saturday, Sunday")
   private String day;
 
-  private String shiftStart; // format: HH:MM(A/P)M e.g. "11:00AM" or "1:37PM"
-  private String shiftEnd; //format: HH:MM(A/P)M e.g. "11:00AM" or "1:37PM"
-  
+  private String shiftStart; // format: HH:MM(A/P)M e.g. "11:00AM" or "01:37PM"
+  private String shiftEnd; //format: HH:MM(A/P)M e.g. "11:00AM" or "01:37PM"
+
   private long driverID;
   private long driverBackupID;
 }

--- a/src/main/java/edu/ucsb/cs156/gauchoride/entities/Shift.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/entities/Shift.java
@@ -4,7 +4,6 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.AccessLevel;
 import javax.persistence.Entity;
 import javax.persistence.Id;
 import javax.persistence.GeneratedValue;
@@ -13,7 +12,7 @@ import java.time.LocalTime;
 
 @Data
 @AllArgsConstructor
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor
 @Builder
 @Entity(name = "shift")
 public class Shift {
@@ -21,8 +20,10 @@ public class Shift {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private long id;
   private String day;
-  private LocalTime shiftStart;
-  private LocalTime shiftEnd;
+  // private LocalTime shiftStart;
+  // private LocalTime shiftEnd;
+  private String shiftStart; //format "HH:MM"
+  private String shiftEnd; //format "HH:MM"
   private long driverID;
   private long driverBackupID;
 }

--- a/src/main/java/edu/ucsb/cs156/gauchoride/entities/Shift.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/entities/Shift.java
@@ -8,7 +8,7 @@ import javax.persistence.Entity;
 import javax.persistence.Id;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
-import java.time.LocalTime;
+import io.swagger.annotations.ApiModelProperty;
 
 @Data
 @AllArgsConstructor
@@ -19,11 +19,13 @@ public class Shift {
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private long id;
+
+  @ApiModelProperty(allowableValues = "Monday, Tuesday, Wednesday, Thursday, Friday, Saturday, Sunday")
   private String day;
-  // private LocalTime shiftStart;
-  // private LocalTime shiftEnd;
-  private String shiftStart; //format "HH:MM"
-  private String shiftEnd; //format "HH:MM"
+
+  private String shiftStart; // format: HH:MM(A/P)M e.g. "11:00AM" or "1:37PM"
+  private String shiftEnd; //format: HH:MM(A/P)M e.g. "11:00AM" or "1:37PM"
+  
   private long driverID;
   private long driverBackupID;
 }

--- a/src/main/java/edu/ucsb/cs156/gauchoride/repositories/ShiftRepository.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/repositories/ShiftRepository.java
@@ -4,7 +4,6 @@ import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
 
 import edu.ucsb.cs156.gauchoride.entities.Shift;
-import java.time.LocalTime;
 
 import java.util.Optional;
 

--- a/src/test/java/edu/ucsb/cs156/gauchoride/controllers/ShiftControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/gauchoride/controllers/ShiftControllerTests.java
@@ -417,7 +417,7 @@ public class ShiftControllerTests extends ControllerTestCase {
 
                 when(shiftRepository.save(eq(shift1))).thenReturn(shift1);
 
-                String postRequestString = "day=Monday&shiftStart=10:30&shiftEnd=12:30";
+                String postRequestString = "day=Monday&shiftStart=10:30&shiftEnd=12:30&driverID="+userId+"&driverBackupID=1";
 
                 // act
                 MvcResult response = mockMvc.perform(

--- a/src/test/java/edu/ucsb/cs156/gauchoride/controllers/ShiftControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/gauchoride/controllers/ShiftControllerTests.java
@@ -394,4 +394,41 @@ public class ShiftControllerTests extends ControllerTestCase {
                 String responseString = response.getResponse().getContentAsString();
                 assertEquals(expectedJson, responseString);
         }
+
+
+        // POST
+
+
+
+        @WithMockUser(roles = { "DRIVER" })
+        @Test
+        public void a_driver_can_post_a_new_shift() throws Exception {
+                // arrange
+
+                long userId = currentUserService.getCurrentUser().getUser().getId();
+
+                Shift shift1 = Shift.builder()
+                                .driverID(userId)
+                                .day("Monday")
+                                .shiftStart("10:30")
+                                .shiftEnd("12:30")
+                                .driverBackupID(1)
+                                .build();
+
+                when(shiftRepository.save(eq(shift1))).thenReturn(shift1);
+
+                String postRequestString = "day=Monday&shiftStart=10:30&shiftEnd=12:30";
+
+                // act
+                MvcResult response = mockMvc.perform(
+                                post("/api/shift/post?" + postRequestString)
+                                                .with(csrf()))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+                verify(shiftRepository, times(1)).save(shift1);
+                String expectedJson = mapper.writeValueAsString(shift1);
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(expectedJson, responseString);
+        }
 }

--- a/src/test/java/edu/ucsb/cs156/gauchoride/controllers/ShiftControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/gauchoride/controllers/ShiftControllerTests.java
@@ -1,0 +1,397 @@
+package edu.ucsb.cs156.gauchoride.controllers;
+
+import edu.ucsb.cs156.gauchoride.repositories.UserRepository;
+import edu.ucsb.cs156.gauchoride.testconfig.TestConfig;
+import edu.ucsb.cs156.gauchoride.ControllerTestCase;
+import edu.ucsb.cs156.gauchoride.entities.Shift;
+import edu.ucsb.cs156.gauchoride.repositories.ShiftRepository;
+
+import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@WebMvcTest(controllers = ShiftController.class)
+@Import(TestConfig.class)
+public class ShiftControllerTests extends ControllerTestCase {
+
+        @MockBean
+        ShiftRepository shiftRepository;
+
+        @MockBean
+        UserRepository userRepository;
+
+        // Authorization tests for /api/shift/all
+
+        @Test
+        public void logged_out_users_cannot_get_all() throws Exception {
+                mockMvc.perform(get("/api/shift/all"))
+                                .andExpect(status().is(403)); // logged out users can't get all
+        }
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void logged_in_users_can_get_all_of_theirs() throws Exception {
+                mockMvc.perform(get("/api/shift/all"))
+                                .andExpect(status().is(200)); // logged
+        }
+
+        @WithMockUser(roles = { "DRIVER" })
+        @Test
+        public void logged_in_driver_can_get_all() throws Exception {
+                mockMvc.perform(get("/api/shift/all"))
+                                .andExpect(status().is(200)); // logged
+        }
+
+        @WithMockUser(roles = { "ADMIN" })
+        @Test
+        public void logged_in_admin_can_get_all() throws Exception {
+                mockMvc.perform(get("/api/shift/all"))
+                                .andExpect(status().is(200)); // logged
+        }
+
+        // Authorization tests for /api/ride_request?id={}
+
+        @Test
+        public void logged_out_users_cannot_get_by_id() throws Exception {
+                mockMvc.perform(get("/api/shift/get?id=7"))
+                                .andExpect(status().is(403)); // logged out users can't get by id
+        }
+
+        // @WithMockUser(roles = { "USER" })
+        // @Test
+        // public void logged_in_users_can_get_by_id_that_is_theirs() throws Exception {
+        //         mockMvc.perform(get("/api/shift/get?id=7"))
+        //                         .andExpect(status().is(404)); // logged, but no id exists
+        // }
+
+        @WithMockUser(roles = { "DRIVER" })
+        @Test
+        public void logged_in_driver_can_get_by_id() throws Exception {
+                mockMvc.perform(get("/api/shift/get?id=7"))
+                                .andExpect(status().is(404)); // logged, but no id exists
+        }
+
+        @WithMockUser(roles = { "ADMIN" })
+        @Test
+        public void logged_in_admin_can_get_by_id() throws Exception {
+                mockMvc.perform(get("/api/shift/get?id=7"))
+                                .andExpect(status().is(404)); // logged, but no id exists
+        }
+
+        // Authorization tests for /api/shift/post
+
+        @Test
+        public void logged_out_users_cannot_post() throws Exception {
+                mockMvc.perform(post("/api/shift/post"))
+                                .andExpect(status().is(403));
+        }
+
+        @WithMockUser(roles = { "DRIVER" })
+        @Test
+        public void logged_in_driver_cannot_post() throws Exception {
+                mockMvc.perform(post("/api/shift/post"))
+                                .andExpect(status().is(403));
+        }
+
+        // // Tests with mocks for database actions
+
+
+
+        // GET BY ID
+
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void test_that_logged_in_user_can_get_by_id_when_the_id_exists_and_user_id_matches() throws Exception {
+
+                // arrange
+
+                long userId = currentUserService.getCurrentUser().getUser().getId();
+
+                Shift shift = Shift.builder()
+                                .driverID(userId)
+                                .day("Monday")
+                                .shiftStart("10:00")
+                                .shiftEnd("12:30")
+                                .driverBackupID(1)
+                                .build();
+
+                when(shiftRepository.findById(eq(7L))).thenReturn(Optional.of(shift));
+
+                // act
+                MvcResult response = mockMvc.perform(get("/api/shift/get?id=7"))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+
+                verify(shiftRepository, times(1)).findById(eq(7L));
+                String expectedJson = mapper.writeValueAsString(shift);
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(expectedJson, responseString);
+        }
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void test_that_logged_in_user_can_get_by_id_when_the_id_does_not_exist() throws Exception {
+
+                // arrange
+
+                long userId = currentUserService.getCurrentUser().getUser().getId();
+
+                when(shiftRepository.findById(eq(7L))).thenReturn(Optional.empty());
+
+                // act
+                MvcResult response = mockMvc.perform(get("/api/shift/get?id=7"))
+                                .andExpect(status().isNotFound()).andReturn();
+
+                // assert
+
+                verify(shiftRepository, times(1)).findById(eq(7L));
+                Map<String, Object> json = responseToJson(response);
+                assertEquals("EntityNotFoundException", json.get("type"));
+                assertEquals("Shift with id 7 not found", json.get("message"));
+        }
+        
+        @WithMockUser(roles = { "ADMIN" , "USER" })
+        @Test
+        public void test_that_logged_in_admin_can_get_by_id_when_the_id_exists() throws Exception {
+
+                // arrange
+
+                long userId = currentUserService.getCurrentUser().getUser().getId();
+
+                Shift shift = Shift.builder()
+                                .driverID(userId)
+                                .day("Monday")
+                                .shiftStart("10:00")
+                                .shiftEnd("12:30")
+                                .driverBackupID(1)
+                                .build();
+
+                when(shiftRepository.findById(eq(7L))).thenReturn(Optional.of(shift));
+
+                // act
+                MvcResult response = mockMvc.perform(get("/api/shift/get?id=7"))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+
+                verify(shiftRepository, times(1)).findById(eq(7L));
+                String expectedJson = mapper.writeValueAsString(shift);
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(expectedJson, responseString);
+        }
+
+        @WithMockUser(roles = { "DRIVER" })
+        @Test
+        public void test_that_logged_in_driver_can_get_by_id_when_the_id_exists() throws Exception {
+
+                // arrange
+
+                long userId = currentUserService.getCurrentUser().getUser().getId();
+                long otherUserId = userId + 1;
+
+                Shift shift = Shift.builder()
+                                .driverID(userId)
+                                .day("Monday")
+                                .shiftStart("10:00")
+                                .shiftEnd("12:30")
+                                .driverBackupID(1)
+                                .build();
+
+                when(shiftRepository.findById(eq(7L))).thenReturn(Optional.of(shift));
+
+                // act
+                MvcResult response = mockMvc.perform(get("/api/shift/get?id=7"))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+
+                verify(shiftRepository, times(1)).findById(eq(7L));
+                String expectedJson = mapper.writeValueAsString(shift);
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(expectedJson, responseString);
+        }
+
+        @WithMockUser(roles = { "ADMIN" , "USER" })
+        @Test
+        public void test_that_logged_in_admin_can_get_by_id_when_the_id_does_not_exist() throws Exception {
+
+                // arrange
+
+                when(shiftRepository.findById(eq(7L))).thenReturn(Optional.empty());
+
+                // act
+                MvcResult response = mockMvc.perform(get("/api/shift/get?id=7"))
+                                .andExpect(status().isNotFound()).andReturn();
+
+                // assert
+
+                verify(shiftRepository, times(1)).findById(eq(7L));
+                Map<String, Object> json = responseToJson(response);
+                assertEquals("EntityNotFoundException", json.get("type"));
+                assertEquals("Shift with id 7 not found", json.get("message"));
+        }
+
+        @WithMockUser(roles = { "DRIVER" })
+        @Test
+        public void test_that_logged_in_driver_can_get_by_id_when_the_id_does_not_exist() throws Exception {
+
+                // arrange
+
+                when(shiftRepository.findById(eq(7L))).thenReturn(Optional.empty());
+
+                // act
+                MvcResult response = mockMvc.perform(get("/api/shift/get?id=7"))
+                                .andExpect(status().isNotFound()).andReturn();
+
+                // assert
+
+                verify(shiftRepository, times(1)).findById(eq(7L));
+                Map<String, Object> json = responseToJson(response);
+                assertEquals("EntityNotFoundException", json.get("type"));
+                assertEquals("Shift with id 7 not found", json.get("message"));
+        }
+        
+
+
+        // GET ALL
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void logged_in_user_can_get_all_shifts() throws Exception {
+
+                long userId = currentUserService.getCurrentUser().getUser().getId();
+
+                Shift shift1 = Shift.builder()
+                                .driverID(userId)
+                                .day("Monday")
+                                .shiftStart("10:30")
+                                .shiftEnd("12:30")
+                                .driverBackupID(1)
+                                .build();
+
+                Shift shift2 = Shift.builder()
+                                .driverID(userId)
+                                .day("Tuesday")
+                                .shiftStart("10:30")
+                                .shiftEnd("12:30")
+                                .driverBackupID(userId + 1)
+                                .build();
+
+                ArrayList<Shift> expectedShifts = new ArrayList<>();
+                expectedShifts.addAll(Arrays.asList(shift1, shift2));
+
+                when(shiftRepository.findAll()).thenReturn(expectedShifts);
+
+                // act
+                MvcResult response = mockMvc.perform(get("/api/shift/all"))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+
+                verify(shiftRepository, times(1)).findAll();
+                String expectedJson = mapper.writeValueAsString(expectedShifts);
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(expectedJson, responseString);
+        }
+
+        @WithMockUser(roles = { "ADMIN" , "USER" })
+        @Test
+        public void logged_in_admin_can_get_all_shifts() throws Exception {
+
+                long userId = currentUserService.getCurrentUser().getUser().getId();
+
+                Shift shift1 = Shift.builder()
+                                .driverID(userId)
+                                .day("Monday")
+                                .shiftStart("10:30")
+                                .shiftEnd("12:30")
+                                .driverBackupID(1)
+                                .build();
+
+                Shift shift2 = Shift.builder()
+                                .driverID(userId)
+                                .day("Tuesday")
+                                .shiftStart("10:30")
+                                .shiftEnd("12:30")
+                                .driverBackupID(userId + 1)
+                                .build();
+
+
+                ArrayList<Shift> expectedShifts = new ArrayList<>();
+                expectedShifts.addAll(Arrays.asList(shift1, shift2));
+
+                when(shiftRepository.findAll()).thenReturn(expectedShifts);
+
+                // act
+                MvcResult response = mockMvc.perform(get("/api/shift/all"))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+
+                verify(shiftRepository, times(1)).findAll();
+                String expectedJson = mapper.writeValueAsString(expectedShifts);
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(expectedJson, responseString);
+        }
+
+        @WithMockUser(roles = { "DRIVER" })
+        @Test
+        public void logged_in_driver_can_get_all_shifts() throws Exception {
+
+                long userId = currentUserService.getCurrentUser().getUser().getId();
+
+                Shift shift1 = Shift.builder()
+                                .driverID(userId)
+                                .day("Monday")
+                                .shiftStart("10:30")
+                                .shiftEnd("12:30")
+                                .driverBackupID(1)
+                                .build();
+
+                Shift shift2 = Shift.builder()
+                                .driverID(userId)
+                                .day("Tuesday")
+                                .shiftStart("10:30")
+                                .shiftEnd("12:30")
+                                .driverBackupID(userId + 1)
+                                .build();
+
+                ArrayList<Shift> expectedShifts = new ArrayList<>();
+                expectedShifts.addAll(Arrays.asList(shift1, shift2));
+                
+                when(shiftRepository.findAll()).thenReturn(expectedShifts);
+                
+                MvcResult response = mockMvc.perform(get("/api/shift/all"))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+
+                verify(shiftRepository, times(1)).findAll();
+                String expectedJson = mapper.writeValueAsString(expectedShifts);
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(expectedJson, responseString);
+        }
+}

--- a/src/test/java/edu/ucsb/cs156/gauchoride/controllers/ShiftControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/gauchoride/controllers/ShiftControllerTests.java
@@ -6,7 +6,6 @@ import edu.ucsb.cs156.gauchoride.ControllerTestCase;
 import edu.ucsb.cs156.gauchoride.entities.Shift;
 import edu.ucsb.cs156.gauchoride.repositories.ShiftRepository;
 
-import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Map;
@@ -14,7 +13,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
-import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MvcResult;
 
@@ -25,7 +23,6 @@ import static org.springframework.security.test.web.servlet.request.SecurityMock
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -70,7 +67,7 @@ public class ShiftControllerTests extends ControllerTestCase {
                                 .andExpect(status().is(200)); // logged
         }
 
-        // Authorization tests for /api/ride_request?id={}
+        // Authorization tests for /api/shift/get?id={}
 
         @Test
         public void logged_out_users_cannot_get_by_id() throws Exception {
@@ -78,12 +75,6 @@ public class ShiftControllerTests extends ControllerTestCase {
                                 .andExpect(status().is(403)); // logged out users can't get by id
         }
 
-        // @WithMockUser(roles = { "USER" })
-        // @Test
-        // public void logged_in_users_can_get_by_id_that_is_theirs() throws Exception {
-        //         mockMvc.perform(get("/api/shift/get?id=7"))
-        //                         .andExpect(status().is(404)); // logged, but no id exists
-        // }
 
         @WithMockUser(roles = { "DRIVER" })
         @Test
@@ -156,8 +147,6 @@ public class ShiftControllerTests extends ControllerTestCase {
         public void test_that_logged_in_user_can_get_by_id_when_the_id_does_not_exist() throws Exception {
 
                 // arrange
-
-                long userId = currentUserService.getCurrentUser().getUser().getId();
 
                 when(shiftRepository.findById(eq(7L))).thenReturn(Optional.empty());
 
@@ -396,8 +385,6 @@ public class ShiftControllerTests extends ControllerTestCase {
 
 
         // POST
-
-
 
         @WithMockUser(roles = { "DRIVER" })
         @Test

--- a/src/test/java/edu/ucsb/cs156/gauchoride/controllers/ShiftControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/gauchoride/controllers/ShiftControllerTests.java
@@ -417,4 +417,36 @@ public class ShiftControllerTests extends ControllerTestCase {
                 String responseString = response.getResponse().getContentAsString();
                 assertEquals(expectedJson, responseString);
         }
+
+        @WithMockUser(roles = { "ADMIN" })
+        @Test
+        public void an_admin_can_post_a_new_shift() throws Exception {
+                // arrange
+
+                long userId = currentUserService.getCurrentUser().getUser().getId();
+
+                Shift shift1 = Shift.builder()
+                                .driverID(userId)
+                                .day("Monday")
+                                .shiftStart("10:30AM")
+                                .shiftEnd("12:30PM")
+                                .driverBackupID(1)
+                                .build();
+
+                when(shiftRepository.save(eq(shift1))).thenReturn(shift1);
+
+                String postRequestString = "day=Monday&shiftStart=10:30AM&shiftEnd=12:30PM&driverID="+userId+"&driverBackupID=1";
+
+                // act
+                MvcResult response = mockMvc.perform(
+                                post("/api/shift/post?" + postRequestString)
+                                                .with(csrf()))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+                verify(shiftRepository, times(1)).save(shift1);
+                String expectedJson = mapper.writeValueAsString(shift1);
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(expectedJson, responseString);
+        }
 }

--- a/src/test/java/edu/ucsb/cs156/gauchoride/controllers/ShiftControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/gauchoride/controllers/ShiftControllerTests.java
@@ -132,8 +132,8 @@ public class ShiftControllerTests extends ControllerTestCase {
                 Shift shift = Shift.builder()
                                 .driverID(userId)
                                 .day("Monday")
-                                .shiftStart("10:00")
-                                .shiftEnd("12:30")
+                                .shiftStart("10:00AM")
+                                .shiftEnd("12:30PM")
                                 .driverBackupID(1)
                                 .build();
 
@@ -184,8 +184,8 @@ public class ShiftControllerTests extends ControllerTestCase {
                 Shift shift = Shift.builder()
                                 .driverID(userId)
                                 .day("Monday")
-                                .shiftStart("10:00")
-                                .shiftEnd("12:30")
+                                .shiftStart("10:00AM")
+                                .shiftEnd("12:30PM")
                                 .driverBackupID(1)
                                 .build();
 
@@ -210,13 +210,12 @@ public class ShiftControllerTests extends ControllerTestCase {
                 // arrange
 
                 long userId = currentUserService.getCurrentUser().getUser().getId();
-                long otherUserId = userId + 1;
 
                 Shift shift = Shift.builder()
                                 .driverID(userId)
                                 .day("Monday")
-                                .shiftStart("10:00")
-                                .shiftEnd("12:30")
+                                .shiftStart("10:00AM")
+                                .shiftEnd("12:30PM")
                                 .driverBackupID(1)
                                 .build();
 
@@ -287,16 +286,16 @@ public class ShiftControllerTests extends ControllerTestCase {
                 Shift shift1 = Shift.builder()
                                 .driverID(userId)
                                 .day("Monday")
-                                .shiftStart("10:30")
-                                .shiftEnd("12:30")
+                                .shiftStart("10:30AM")
+                                .shiftEnd("12:30PM")
                                 .driverBackupID(1)
                                 .build();
 
                 Shift shift2 = Shift.builder()
                                 .driverID(userId)
                                 .day("Tuesday")
-                                .shiftStart("10:30")
-                                .shiftEnd("12:30")
+                                .shiftStart("10:30AM")
+                                .shiftEnd("12:30PM")
                                 .driverBackupID(userId + 1)
                                 .build();
 
@@ -326,16 +325,16 @@ public class ShiftControllerTests extends ControllerTestCase {
                 Shift shift1 = Shift.builder()
                                 .driverID(userId)
                                 .day("Monday")
-                                .shiftStart("10:30")
-                                .shiftEnd("12:30")
+                                .shiftStart("10:30AM")
+                                .shiftEnd("12:30PM")
                                 .driverBackupID(1)
                                 .build();
 
                 Shift shift2 = Shift.builder()
                                 .driverID(userId)
                                 .day("Tuesday")
-                                .shiftStart("10:30")
-                                .shiftEnd("12:30")
+                                .shiftStart("10:30AM")
+                                .shiftEnd("12:30PM")
                                 .driverBackupID(userId + 1)
                                 .build();
 
@@ -366,16 +365,16 @@ public class ShiftControllerTests extends ControllerTestCase {
                 Shift shift1 = Shift.builder()
                                 .driverID(userId)
                                 .day("Monday")
-                                .shiftStart("10:30")
-                                .shiftEnd("12:30")
+                                .shiftStart("10:30AM")
+                                .shiftEnd("12:30PM")
                                 .driverBackupID(1)
                                 .build();
 
                 Shift shift2 = Shift.builder()
                                 .driverID(userId)
                                 .day("Tuesday")
-                                .shiftStart("10:30")
-                                .shiftEnd("12:30")
+                                .shiftStart("10:30AM")
+                                .shiftEnd("12:30PM")
                                 .driverBackupID(userId + 1)
                                 .build();
 
@@ -410,14 +409,14 @@ public class ShiftControllerTests extends ControllerTestCase {
                 Shift shift1 = Shift.builder()
                                 .driverID(userId)
                                 .day("Monday")
-                                .shiftStart("10:30")
-                                .shiftEnd("12:30")
+                                .shiftStart("10:30AM")
+                                .shiftEnd("12:30PM")
                                 .driverBackupID(1)
                                 .build();
 
                 when(shiftRepository.save(eq(shift1))).thenReturn(shift1);
 
-                String postRequestString = "day=Monday&shiftStart=10:30&shiftEnd=12:30&driverID="+userId+"&driverBackupID=1";
+                String postRequestString = "day=Monday&shiftStart=10:30AM&shiftEnd=12:30PM&driverID="+userId+"&driverBackupID=1";
 
                 // act
                 MvcResult response = mockMvc.perform(


### PR DESCRIPTION
In this PR, I add the backend Post and Get functionality to the shift table in #8. Michael helped me with the Post tests, and it works on Swagger. From this, drivers should be able to add their ride shifts, and any user can get all ride shifts. The shiftStart and end parameters in shift entity has been changed to type String instead of LocalTime, as I was unable to test on LocalTime objects in Swagger.