### PR TITLE
Ian - Shift page that's consistent with backend

### DIFF
--- a/frontend/src/fixtures/shiftFixtures.js
+++ b/frontend/src/fixtures/shiftFixtures.js
@@ -3,23 +3,26 @@ const shiftFixtures = {
         {
             "id": 1,
             "day": "Monday",
-            "shift": "8AM-11AM",
-            "driver": "Adam",
-            "driverBackup": "Eve"
+            "shiftStart": "8AM",
+            "shiftEnd": "11AM",
+            "driverID": 1,
+            "driverBackupID": 3
         },
         {
             "id": 2,
             "day": "Tuesday",
-            "shift": "11AM-2PM",
-            "driver": "Bob",
-            "driverBackup": "Adam"
+            "shiftStart": "11AM",
+            "shiftEnd": "2PM",
+            "driverID": 2,
+            "driverBackupID": 1
         },
         {
             "id": 3,
             "day": "Thursday",
-            "shift": "3PM-6PM",
-            "driver": "Eve",
-            "driverBackup": "Bob"
+            "shiftStart": "3PM",
+            "shiftEnd": "6PM",
+            "driverID": 3,
+            "driverBackupID": 2
         },
     ]
 }

--- a/frontend/src/fixtures/shiftFixtures.js
+++ b/frontend/src/fixtures/shiftFixtures.js
@@ -3,24 +3,24 @@ const shiftFixtures = {
         {
             "id": 1,
             "day": "Monday",
-            "shiftStart": "8AM",
-            "shiftEnd": "11AM",
+            "shiftStart": "08:00AM",
+            "shiftEnd": "11:00AM",
             "driverID": 1,
             "driverBackupID": 3
         },
         {
             "id": 2,
             "day": "Tuesday",
-            "shiftStart": "11AM",
-            "shiftEnd": "2PM",
+            "shiftStart": "11:00AM",
+            "shiftEnd": "02:00PM",
             "driverID": 2,
             "driverBackupID": 1
         },
         {
             "id": 3,
             "day": "Thursday",
-            "shiftStart": "3PM",
-            "shiftEnd": "6PM",
+            "shiftStart": "03:00PM",
+            "shiftEnd": "06:00PM",
             "driverID": 3,
             "driverBackupID": 2
         },

--- a/frontend/src/main/components/Shift/ShiftTable.js
+++ b/frontend/src/main/components/Shift/ShiftTable.js
@@ -11,20 +11,24 @@ export default function ShiftTable({ shift }) {
             accessor: 'id', // accessor is the "key" in the data
         },
         {
-            Header: 'day',
+            Header: 'Day',
             accessor: 'day',
         },
         {
-            Header: 'shift',
-            accessor: 'shift',
+            Header: 'Shift start',
+            accessor: 'shiftStart',
         },
         {
-            Header: 'driver',
-            accessor: 'driver'
+            Header: 'Shift end',
+            accessor: 'shiftEnd',
         },
         {
-            Header: 'driver backup',
-            accessor: 'driverBackup',
+            Header: 'Driver',
+            accessor: 'driverID'
+        },
+        {
+            Header: 'Backup driver',
+            accessor: 'driverBackupID',
         }
     ];
 

--- a/frontend/src/main/pages/ShiftPage.js
+++ b/frontend/src/main/pages/ShiftPage.js
@@ -8,9 +8,9 @@ const ShiftPage = () => {
     const { data: shift, error: _error, status: _status } =
         useBackend(
             // Stryker disable next-line all : don't test internal caching of React Query
-            ["/api/shift"],
+            ["/api/shift/all"],
             // Stryker disable next-line StringLiteral,ObjectLiteral : since "GET" is default, "" is an equivalent mutation
-            { method: "GET", url: "/api/shift" },
+            { method: "GET", url: "/api/shift/all" },
             []
         );
 

--- a/frontend/src/tests/components/Shift/ShiftTable.test.js
+++ b/frontend/src/tests/components/Shift/ShiftTable.test.js
@@ -46,13 +46,13 @@ describe("ShiftTable tests", () => {
 
         expect(getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1");
         expect(getByTestId(`${testId}-cell-row-0-col-day`)).toHaveTextContent("Monday");
-        expect(getByTestId(`${testId}-cell-row-0-col-shiftStart`)).toHaveTextContent("8AM");
-        expect(getByTestId(`${testId}-cell-row-0-col-shiftEnd`)).toHaveTextContent("11AM");
+        expect(getByTestId(`${testId}-cell-row-0-col-shiftStart`)).toHaveTextContent("08:00AM");
+        expect(getByTestId(`${testId}-cell-row-0-col-shiftEnd`)).toHaveTextContent("11:00AM");
         expect(getByTestId(`${testId}-cell-row-0-col-driverID`)).toHaveTextContent("1");
         expect(getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent("2");
         expect(getByTestId(`${testId}-cell-row-1-col-day`)).toHaveTextContent("Tuesday");
-        expect(getByTestId(`${testId}-cell-row-1-col-shiftStart`)).toHaveTextContent("11AM");
-        expect(getByTestId(`${testId}-cell-row-1-col-shiftEnd`)).toHaveTextContent("2PM");
+        expect(getByTestId(`${testId}-cell-row-1-col-shiftStart`)).toHaveTextContent("11:00AM");
+        expect(getByTestId(`${testId}-cell-row-1-col-shiftEnd`)).toHaveTextContent("02:00PM");
         expect(getByTestId(`${testId}-cell-row-1-col-driverID`)).toHaveTextContent("2");
 
       });

--- a/frontend/src/tests/components/Shift/ShiftTable.test.js
+++ b/frontend/src/tests/components/Shift/ShiftTable.test.js
@@ -30,8 +30,8 @@ describe("ShiftTable tests", () => {
             </QueryClientProvider>
         );
     
-        const expectedHeaders = ["id", "day", "shift", "driver", "driver backup"];
-        const expectedFields = ["id", "day", "shift", "driver", "driverBackup"];
+        const expectedHeaders = ["id", "Day", "Shift start", "Shift end", "Driver", "Backup driver"];
+        const expectedFields = ["id", "day", "shiftStart", "shiftEnd", "driverID", "driverBackupID"];
         const testId = "ShiftTable";
 
         expectedHeaders.forEach( (headerText)=> {
@@ -46,12 +46,14 @@ describe("ShiftTable tests", () => {
 
         expect(getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1");
         expect(getByTestId(`${testId}-cell-row-0-col-day`)).toHaveTextContent("Monday");
-        expect(getByTestId(`${testId}-cell-row-0-col-shift`)).toHaveTextContent("8AM-11AM");
-        expect(getByTestId(`${testId}-cell-row-0-col-driver`)).toHaveTextContent("Adam");
+        expect(getByTestId(`${testId}-cell-row-0-col-shiftStart`)).toHaveTextContent("8AM");
+        expect(getByTestId(`${testId}-cell-row-0-col-shiftEnd`)).toHaveTextContent("11AM");
+        expect(getByTestId(`${testId}-cell-row-0-col-driverID`)).toHaveTextContent("1");
         expect(getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent("2");
         expect(getByTestId(`${testId}-cell-row-1-col-day`)).toHaveTextContent("Tuesday");
-        expect(getByTestId(`${testId}-cell-row-1-col-shift`)).toHaveTextContent("11AM-2PM");
-        expect(getByTestId(`${testId}-cell-row-1-col-driver`)).toHaveTextContent("Bob");
+        expect(getByTestId(`${testId}-cell-row-1-col-shiftStart`)).toHaveTextContent("11AM");
+        expect(getByTestId(`${testId}-cell-row-1-col-shiftEnd`)).toHaveTextContent("2PM");
+        expect(getByTestId(`${testId}-cell-row-1-col-driverID`)).toHaveTextContent("2");
 
       });
 });

--- a/frontend/src/tests/pages/ShiftPage.test.js
+++ b/frontend/src/tests/pages/ShiftPage.test.js
@@ -32,7 +32,7 @@ describe("ShiftPage tests", () => {
 
     test("renders without crashing on three users", async () => {
         const queryClient = new QueryClient();
-        axiosMock.onGet("/api/shift").reply(200, shiftFixtures.threeShifts);
+        axiosMock.onGet("/api/shift/all").reply(200, shiftFixtures.threeShifts);
 
         const { getByText } = render(
             <QueryClientProvider client={queryClient}>
@@ -49,7 +49,7 @@ describe("ShiftPage tests", () => {
 
     test("renders empty table when backend unavailable", async () => {
         const queryClient = new QueryClient();
-        axiosMock.onGet("/api/shift").timeout();
+        axiosMock.onGet("/api/shift/all").timeout();
 
         const restoreConsole = mockConsole();
 
@@ -71,7 +71,7 @@ describe("ShiftPage tests", () => {
     test("shifttable toggle admin tests (dont need this when table is fixed)", async ()=>{
         setupDriverUser();
         const queryClient = new QueryClient();
-        axiosMock.onGet("/api/shift").reply(200, shiftFixtures.threeShifts);
+        axiosMock.onGet("/api/shift/all").reply(200, shiftFixtures.threeShifts);
         const { getByText} = render(
             <QueryClientProvider client={queryClient}>
                 <MemoryRouter>


### PR DESCRIPTION
In this PR, I updated the API link and column accessors in ShiftPage and ShiftTable so they are now consistent with the ready-to-merge Shift backend in PR #56. I also updated the corresponding tests and fixtures so they also reflect the changes. This PR is part of #8.

_This branch is not ready to be merged until PR #51 and #56 are merged. Marking it as draft for now._

<img width="1440" alt="image" src="https://github.com/ucsb-cs156-s23/proj-gauchoride-s23-5pm-4/assets/12759287/f95aed42-7ba2-4364-8f73-9b8a0a76fdc2">